### PR TITLE
Enable viewing requests as a list

### DIFF
--- a/src/components/NewRequestTile.svelte
+++ b/src/components/NewRequestTile.svelte
@@ -9,13 +9,13 @@ import { format } from 'date-fns'
 
 <style>
 .plus-icon {
-  margin: 25% 0;
+  padding: 25% 0;
   text-align: center;
   font-size: 5rem;
   line-height: 1em;
 }
 .request-tile {
-  border-color: #63c774;
+  border-color: var(--success);
   cursor: pointer;
   height: 100%;
 }

--- a/src/components/NewRequestTile.svelte
+++ b/src/components/NewRequestTile.svelte
@@ -15,7 +15,7 @@ import { format } from 'date-fns'
   line-height: 1em;
 }
 .request-tile {
-  border-color: #7ca8cf;
+  border-color: #63c774;
   cursor: pointer;
   height: 100%;
 }
@@ -23,11 +23,11 @@ import { format } from 'date-fns'
 
 <div class="card request-tile bg-light" on:click={ () => push(`/requests/new`) }>
   <div class="card-body p-2 position-relative">
-    <div class="card-text plus-icon text-primary">+</div>
+    <div class="card-text plus-icon text-success">+</div>
   </div>
-  <div class="card-footer p-2 bg-primary">
+  <div class="card-footer p-2 bg-success">
     <div class="row">
-      <div class="col text-center"><a class="text-light" href="#/requests/new">Make a new request</a></div>
+      <div class="col text-center"><a class="text-light" href="#/requests/new">Make a request</a></div>
     </div>
   </div>
 </div>

--- a/src/components/RequestImage.svelte
+++ b/src/components/RequestImage.svelte
@@ -5,6 +5,7 @@ import SizeIndicator from './SizeIndicator.svelte'
 
 export let request = {}
 export let cssClass = ''
+export let showSize = true
 
 $: size = request.size
 $: photoUrl = request.photo && request.photo.url || ''
@@ -44,5 +45,5 @@ function getGraphicForSize(requestSize) {
 </style>
 
 <div style="background-image: url({imgUrl})" class:request-photo={photoUrl} class:generic-graphic={!photoUrl} class="{cssClass}">
-  <div class="size-indicator-container"><SizeIndicator {size} /></div>
+  <div class:d-none={!showSize} class="size-indicator-container"><SizeIndicator {size} /></div>
 </div>

--- a/src/components/RequestListEntry.svelte
+++ b/src/components/RequestListEntry.svelte
@@ -31,6 +31,8 @@ $: size = request.size
         <span class="card-text">{request.destination}</span>
       </div>
     </div>
-    <div class="col-auto p-1"><UserAvatar {user} /></div>
+    <div class="col-auto p-2"><SizeIndicator {size} /></div>
+    <div class="col-auto p-2"><UserAvatar {user} />
+    </div>
   </div>
 </div>

--- a/src/components/RequestListEntry.svelte
+++ b/src/components/RequestListEntry.svelte
@@ -1,0 +1,36 @@
+<script>
+import RequestImage from '../components/RequestImage.svelte'
+import SizeIndicator from '../components/SizeIndicator.svelte'
+import UserAvatar from '../components/UserAvatar.svelte'
+import { push } from 'svelte-spa-router'
+import { format } from 'date-fns'
+
+export let request;
+
+$: user = request.createdBy || {}
+$: size = request.size
+</script>
+
+<style>
+.request-list-entry {
+  border-color: rgba(0, 0, 0, 0.25);
+  cursor: pointer;
+}
+</style>
+
+<div class="card request-list-entry h-100" on:click={ () => push(`/requests/${request.id}`) }>
+  <div class="row no-gutters h-100">
+    <div class="col-1">
+      <div class="card-img text-center h-100">
+        <RequestImage {request} showSize={false} />
+      </div>
+    </div>
+    <div class="col">
+      <div class="card-body p-2">
+        <b class="card-title">{request.title}</b>
+        <span class="card-text">{request.destination}</span>
+      </div>
+    </div>
+    <div class="col-auto p-1"><UserAvatar {user} /></div>
+  </div>
+</div>

--- a/src/components/RequestListEntry.svelte
+++ b/src/components/RequestListEntry.svelte
@@ -12,9 +12,17 @@ $: size = request.size
 </script>
 
 <style>
+.card-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0;
+}
 .request-list-entry {
   border-color: rgba(0, 0, 0, 0.25);
   cursor: pointer;
+}
+.request-list-entry:hover {
+  border-color: var(--blue);
 }
 </style>
 
@@ -27,8 +35,8 @@ $: size = request.size
     </div>
     <div class="col">
       <div class="card-body p-2">
-        <b class="card-title">{request.title}</b>
-        <span class="card-text">{request.destination}</span>
+        <h3 class="card-title d-inline-block">{request.title}</h3>
+        <span class="card-text">| {request.destination}</span>
       </div>
     </div>
     <div class="col-auto p-2"><SizeIndicator {size} /></div>

--- a/src/views/NewRequest.svelte
+++ b/src/views/NewRequest.svelte
@@ -3,7 +3,7 @@ import RequestImage from '../components/RequestImage.svelte'
 import SizeSelector from '../components/SizeSelector.svelte'
 import Uploader from '../components/Uploader.svelte'
 import { getUser, createPost } from '../data/gqlQueries'
-import { push } from 'svelte-spa-router'
+import { push, pop } from 'svelte-spa-router'
 import { format, addMonths } from 'date-fns'
 import { GooglePlacesAutocomplete } from '@beyonk/svelte-googlemaps' //https://github.com/beyonk-adventures/svelte-googlemaps
 
@@ -166,7 +166,7 @@ function imageUploaded(event) {
 
   <div class="form-row form-group">
     <div class="col-auto">
-      <a href="#/requests" class="btn btn-outline-dark">Cancel</a>
+      <a href="#/requests" on:click|preventDefault={() => pop()} class="btn btn-outline-dark">« cancel</a>
     </div>
     <div class="col"></div>
     <div class="col-auto">

--- a/src/views/Request.svelte
+++ b/src/views/Request.svelte
@@ -2,7 +2,7 @@
 import RequestImage from '../components/RequestImage.svelte'
 import SizeIndicator from '../components/SizeIndicator.svelte'
 import { getRequest, cancelPost } from '../data/gqlQueries'
-import { push } from 'svelte-spa-router'
+import { push, pop } from 'svelte-spa-router'
 
 export let params = {} // URL path parameters, provided by router.
 
@@ -86,4 +86,4 @@ div.card-img {
   </div>
 </div>
 
-<a href="#/requests" class="text-secondary">« back to requests</a>
+<a href="#/requests" on:click|preventDefault={() => pop()} class="text-secondary">« back to requests</a>

--- a/src/views/Requests.svelte
+++ b/src/views/Requests.svelte
@@ -1,4 +1,5 @@
 <script>
+import RequestListEntry from '../components/RequestListEntry.svelte'
 import RequestTile from '../components/RequestTile.svelte'
 import NewRequestTile from '../components/NewRequestTile.svelte'
 import SizeFilter from '../components/SizeFilter.svelte'
@@ -18,6 +19,7 @@ let requestFilter = {}
 let me = {}
 let queryStringData
 let requests = []; loadRequests()
+let showAsList = false
 
 $: queryStringData = qs.parse($querystring)
 $: requestFilter = populateFilterFrom(queryStringData)
@@ -25,6 +27,7 @@ $: filteredRequests = filterRequests(requests, requestFilter)
 $: isAllRequests = !isCreatorSelected(requestFilter) && !isProviderSelected(requestFilter)
 $: isJustMyRequests = isSelectedCreator(me.id, requestFilter)
 $: isJustMyCommitments = isSelectedProvider(me.id, requestFilter)
+$: showAsList = queryStringData.hasOwnProperty('list')
 
 function populateFilterFrom(queryStringData) {
   return {
@@ -188,9 +191,17 @@ function isProviderSelected(requestFilter) {
     
     <div class:d-none={!hasLoaded} class="form-row align-items-stretch">
       {#each filteredRequests as request}
-        <div class="col-6 mb-1 my-sm-1 col-md-6 col-lg-4 col-xl-3"><RequestTile {request} /></div>
+        {#if showAsList }
+          <div class="col-12 my-1"><RequestListEntry {request} /></div>
+        {:else}
+          <div class="col-6 mb-1 my-sm-1 col-md-6 col-lg-4 col-xl-3"><RequestTile {request} /></div>
+        {/if}
       {/each}
-      <div class="col-6 mb-1 my-sm-1 col-md-6 col-lg-4 col-xl-3"><NewRequestTile /></div>
+      
+      <div class:d-md-block={showAsList} class="d-none col-12 my-1 text-right">
+        <a href="#/requests/new" class="btn btn-success btn-sm"><span style="font-size: larger">+</span> Make a request</a>
+      </div>
+      <div class:d-md-block={!showAsList} class="d-none col-6 mb-1 my-sm-1 col-md-6 col-lg-4 col-xl-3"><NewRequestTile /></div>
     </div>
     
     <p class:d-none={!errorMessage}>🧨 Something went wrong: {errorMessage}</p>

--- a/src/views/Requests.svelte
+++ b/src/views/Requests.svelte
@@ -12,8 +12,11 @@ let hasLoaded = false
 
 let isAllRequests
 let isJustMyRequests
+let isJustMyCommitments
+let filteredRequests
 let requestFilter = {}
 let me = {}
+let queryStringData
 let requests = []; loadRequests()
 
 $: queryStringData = qs.parse($querystring)

--- a/src/views/Requests.svelte
+++ b/src/views/Requests.svelte
@@ -144,22 +144,46 @@ function isCreatorSelected(requestFilter) {
 function isProviderSelected(requestFilter) {
   return requestFilter.provider && requestFilter.provider.id
 }
+
+function viewAsGrid() {
+  updateQueryString({
+    list: null,
+  })
+}
+
+function viewAsList() {
+  updateQueryString({
+    list: 1,
+  })
+}
 </script>
 
 <div class="row">
-  <div class="col-12 col-sm-auto text-center text-sm-left">
+  <div class="col-12 col-md-auto text-center text-sm-left">
     <h2>Requests</h2>
   </div>
   <div class="col text-right">
-    <button class="btn btn-sm m-1" on:click={() => selectCreator(null)} class:btn-primary={isAllRequests} class:btn-outline-primary={!isAllRequests}>
-      All
-    </button>
-    <button class="btn btn-sm m-1" on:click={() => selectCreator(me.id)} class:btn-primary={isJustMyRequests} class:btn-outline-primary={!isJustMyRequests}>
-      My Requests
-    </button>
-    <button class="btn btn-sm m-1" on:click={() => selectProvider(me.id)} class:btn-primary={isJustMyCommitments} class:btn-outline-primary={!isJustMyCommitments}>
-      My Commitments
-    </button>
+    <div class="row">
+      <div class="col-12 text-center col-sm text-sm-left text-md-right">
+        <button class="btn btn-sm my-1 mx-0" on:click={() => selectCreator(null)} class:btn-primary={isAllRequests} class:btn-outline-primary={!isAllRequests}>
+          All
+        </button>
+        <button class="btn btn-sm my-1 mx-0" on:click={() => selectCreator(me.id)} class:btn-primary={isJustMyRequests} class:btn-outline-primary={!isJustMyRequests}>
+          My Requests
+        </button>
+        <button class="btn btn-sm my-1 mx-0" on:click={() => selectProvider(me.id)} class:btn-primary={isJustMyCommitments} class:btn-outline-primary={!isJustMyCommitments}>
+          My Commitments
+        </button>
+      </div>
+      <div class="col-12 text-center col-sm-auto text-sm-right">
+        <button class="btn btn-sm my-1 mx-0" on:click={() => viewAsGrid()} class:btn-secondary={!showAsList} class:btn-outline-secondary={showAsList}>
+          Grid
+        </button>
+        <button class="btn btn-sm my-1 mx-0" on:click={() => viewAsList()} class:btn-secondary={showAsList} class:btn-outline-secondary={!showAsList}>
+          List
+        </button>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/src/views/Requests.svelte
+++ b/src/views/Requests.svelte
@@ -176,11 +176,11 @@ function viewAsList() {
         </button>
       </div>
       <div class="col-12 text-center col-sm-auto text-sm-right">
-        <button class="btn btn-sm my-1 mx-0" on:click={() => viewAsGrid()} class:btn-secondary={!showAsList} class:btn-outline-secondary={showAsList}>
-          Grid
+        <button class="btn btn-sm my-1 mx-0" title="Show as a grid" on:click={() => viewAsGrid()} class:btn-secondary={!showAsList} class:btn-outline-secondary={showAsList}>
+          <svg class="lnr lnr-file-empty"><use xlink:href="#lnr-file-empty"></use></svg>
         </button>
-        <button class="btn btn-sm my-1 mx-0" on:click={() => viewAsList()} class:btn-secondary={showAsList} class:btn-outline-secondary={!showAsList}>
-          List
+        <button class="btn btn-sm my-1 mx-0" title="Show as a list" on:click={() => viewAsList()} class:btn-secondary={showAsList} class:btn-outline-secondary={!showAsList}>
+          <svg class="lnr lnr-list"><use xlink:href="#lnr-list"></use></svg>
         </button>
       </div>
     </div>

--- a/src/views/Requests.svelte
+++ b/src/views/Requests.svelte
@@ -222,7 +222,7 @@ function viewAsList() {
         {/if}
       {/each}
       
-      <div class:d-md-block={showAsList} class="d-none col-12 my-1 text-right">
+      <div class:d-md-block={showAsList} class="d-none col-12 my-1">
         <a href="#/requests/new" class="btn btn-success btn-sm"><span style="font-size: larger">+</span> Make a request</a>
       </div>
       <div class:d-md-block={!showAsList} class="d-none col-6 mb-1 my-sm-1 col-md-6 col-lg-4 col-xl-3"><NewRequestTile /></div>


### PR DESCRIPTION
**Added:**
- Enable showing requests as entries in a list.
- Add buttons for grid/list and adjust layout accordingly.

**Fixed:**
- Change "Make a request" tile to match (green) button in nav.
- Fix padding around "+" on NewRequestTile.
- Preserve Request page view when backing out of request-details or add-request pages.