### PR TITLE
Enable showing bootstrap width

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@ make
 
 Navigate to [http://wecarry.local:5000](http://wecarry.local:5000). You should see your app running. Edit a component file in `src`, save it, and the page will automatically reload with your changes.
 
+To see what Bootstrap responsive breakpoint you are currently viewing, add the following to the `Footer.svelte`:
+
+```
+<script>
+// ADD THIS:
+import BootstrapWidthIndicator from '../components/BootstrapWidthIndicator.svelte'
+</script>
+
+...
+
+<footer ...>
+    ...
+
+    // AND ADD THIS:
+    <span class="mx-2 text-muted float-right"><BootstrapWidthIndicator /></span>
+</footer>
+```
+
 ## Deployment
 
 ```bash

--- a/src/components/BootstrapWidthIndicator.svelte
+++ b/src/components/BootstrapWidthIndicator.svelte
@@ -1,0 +1,5 @@
+<span class="d-sm-none">x-small</span>
+<span class="d-none d-sm-inline d-md-none">small</span>
+<span class="d-none d-md-inline d-lg-none">medium</span>
+<span class="d-none d-lg-inline d-xl-none">large</span>
+<span class="d-none d-xl-inline">x-large</span>


### PR DESCRIPTION
As I'm working on the request details page redesign, I ended up wanting to be able to easily see which Bootstrap responsive breakpoint I was at. This is the result of that, and I thought it was worth saving for future such work.