### PR TITLE
Use all available width, up to xl breakpoint

### DIFF
--- a/src/components/App.svelte
+++ b/src/components/App.svelte
@@ -32,7 +32,7 @@ function loadData() {
 
 <Nav user={$me} {minimal} />
 
-<main class="container">
+<main class="container-xl">
   <Error />
 
   <Router {routes} />


### PR DESCRIPTION
@wcjr, what do you think about switching from having the content be exactly the sm, md, lg, or xl widths to instead using as much width as is available, up to the xl width?

This could mean some intermediate-width screens might have a slightly less perfect look (since we no longer only care about 4 specific widths, instead possibly showing all widths up to xl). However, it means that less horizontal space is wasted on intermediate-width screens since the content would be allowed to expand out to use it (up to a limit).