### PR TITLE
Fix profile layout at medium width view

### DIFF
--- a/src/views/Profile.svelte
+++ b/src/views/Profile.svelte
@@ -22,9 +22,9 @@ async function saveNewNickname() {
 </script>
 
 <div class="row pt-4">
-  <div class="col-lg"/>
+  <div class="col-md"/>
 
-  <div class="col-lg-2 d-flex flex-column align-items-center">
+  <div class="col-md-2 d-flex flex-column align-items-center">
     <UserAvatar user={$me} />
     
     <div class="pt-2">
@@ -32,7 +32,7 @@ async function saveNewNickname() {
     </div>
   </div>
 
-  <div class="col-lg-5">
+  <div class="col-md-5">
     <div class="form-group">
       {#if editingNickname}
         <form on:submit|preventDefault={saveNewNickname} class="input-group input-group-lg">
@@ -61,5 +61,5 @@ async function saveNewNickname() {
     {/each}
   </div>
 
-  <div class="col-lg"/>
+  <div class="col-md"/>
 </div>  


### PR DESCRIPTION
Using all of the available width put the name and email address too far
to the left at a medium Bootstrap width. This now uses the side-by-side
layout at medium (instead of the above-below layout).