### PR TITLE
Only request the GooglePlacesAutocomplete fields we'll use

### DIFF
--- a/src/views/CreateOrUpdateRequest.svelte
+++ b/src/views/CreateOrUpdateRequest.svelte
@@ -20,7 +20,8 @@ let imageUrl = ''
 // so we could use house addresses, lat/long, etc...no need for restrictions.  See 
 // (https://developers.google.com/places/supported_types#table3 && https://github.com/beyonk-adventures/svelte-googlemaps/blob/master/src/GooglePlacesAutocomplete.svelte#L15)
 const options = {
-  types: []
+  types: [],
+  fields: ['geometry', 'formatted_address', 'address_components']
 }
 
 const newRequest = {


### PR DESCRIPTION
The billing apparently takes into account how many fields you request, and the
recommendation for production usage is to only request what you use.