### PR TITLE
Add request-origin support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       "dev": true
     },
     "@beyonk/svelte-googlemaps": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@beyonk/svelte-googlemaps/-/svelte-googlemaps-2.1.2.tgz",
-      "integrity": "sha512-w9QVguJl9iutrsbT2Vnd2Kp/KputcsvfmPt0QQE/GvF41XTCifFes1ePNmWL7+sQIydyfmDYyEYwW2VqqLEksQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@beyonk/svelte-googlemaps/-/svelte-googlemaps-2.2.0.tgz",
+      "integrity": "sha512-OloT0362osUlfmhazsER4pHYNXpb/OuRv/ek4xs9gJPr18tzNmTbSm9odhuc+FvOuy4jdMFgKkjmMsvvDpOYVg==",
       "dev": true,
       "requires": {
         "@beyonk/async-script-loader": "^1.0.3"
@@ -68,6 +68,12 @@
       "requires": {
         "rollup-pluginutils": "^2.5.0"
       }
+    },
+    "@silintl/svelte-google-places-autocomplete": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@silintl/svelte-google-places-autocomplete/-/svelte-google-places-autocomplete-0.1.0.tgz",
+      "integrity": "sha512-f6MTIBbAJTx0Alg/6O95OOP5g2HHtlxm9u5cRUH8LTMSXE8l4QjMIIlNbxgiq4uQTD3EH2Y/jjpER8HQk5w/5g==",
+      "dev": true
     },
     "@types/estree": {
       "version": "0.0.40",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,21 +24,6 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "@beyonk/async-script-loader": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@beyonk/async-script-loader/-/async-script-loader-1.0.3.tgz",
-      "integrity": "sha512-EX204cmtpjHRyyGsNzkIvOX74OdzP974ICvAT67/7EH0eSHoAKRTvqA9b6s1bKk6Phx1JR5ReSOAI4dbjj72uA==",
-      "dev": true
-    },
-    "@beyonk/svelte-googlemaps": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@beyonk/svelte-googlemaps/-/svelte-googlemaps-2.2.0.tgz",
-      "integrity": "sha512-OloT0362osUlfmhazsER4pHYNXpb/OuRv/ek4xs9gJPr18tzNmTbSm9odhuc+FvOuy4jdMFgKkjmMsvvDpOYVg==",
-      "dev": true,
-      "requires": {
-        "@beyonk/async-script-loader": "^1.0.3"
-      }
-    },
     "@fortawesome/fontawesome-common-types": {
       "version": "0.2.26",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.26.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,9 +55,9 @@
       }
     },
     "@silintl/svelte-google-places-autocomplete": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@silintl/svelte-google-places-autocomplete/-/svelte-google-places-autocomplete-0.1.0.tgz",
-      "integrity": "sha512-f6MTIBbAJTx0Alg/6O95OOP5g2HHtlxm9u5cRUH8LTMSXE8l4QjMIIlNbxgiq4uQTD3EH2Y/jjpER8HQk5w/5g==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@silintl/svelte-google-places-autocomplete/-/svelte-google-places-autocomplete-0.1.1.tgz",
+      "integrity": "sha512-neM2844GWm8F2yxAa7PZBItmHHmH6xmE08iwYc1Dz4JhX3SxfOf4V9jXgpwTtk909+L0YE3X1VCm3be9RV3NRw==",
       "dev": true
     },
     "@types/estree": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@beyonk/svelte-googlemaps": "^2.1.2",
     "@fortawesome/free-solid-svg-icons": "^5.12.0",
     "@rollup/plugin-json": "^4.0.0",
+    "@silintl/svelte-google-places-autocomplete": "^0.1.0",
     "bootstrap": "^4.4.1",
     "date-fns": "^2.8.1",
     "fa-svelte": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "devDependencies": {
     "@fortawesome/free-solid-svg-icons": "^5.12.0",
     "@rollup/plugin-json": "^4.0.0",
-    "@silintl/svelte-google-places-autocomplete": "^0.1.0",
+    "@silintl/svelte-google-places-autocomplete": "^0.1.1",
     "bootstrap": "^4.4.1",
     "date-fns": "^2.8.1",
     "fa-svelte": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "svelte-app",
   "version": "1.0.0",
   "devDependencies": {
-    "@beyonk/svelte-googlemaps": "^2.1.2",
     "@fortawesome/free-solid-svg-icons": "^5.12.0",
     "@rollup/plugin-json": "^4.0.0",
     "@silintl/svelte-google-places-autocomplete": "^0.1.0",

--- a/src/components/LocationInput.svelte
+++ b/src/components/LocationInput.svelte
@@ -1,0 +1,34 @@
+<script>
+import GooglePlacesAutocomplete from '@silintl/svelte-google-places-autocomplete'
+import { createEventDispatcher } from 'svelte'
+
+export let googlePlacesApiKey
+export let placeholder
+
+const dispatch = createEventDispatcher()
+const options = {
+  fields: ['address_components', 'geometry'],
+  types: ['(cities)']
+}
+
+function onPlaceChanged(event) {
+  
+  console.log('place_changed', event.detail) // TEMP
+  
+  const place = event.detail.place
+  const description = event.detail.text
+  dispatch('locationSelected', {
+    description: description,
+    latitude: place.geometry.location.lat(),
+    longitude: place.geometry.location.lng(),
+    country: extractCountryCode(place.address_components),
+  })
+}
+
+function extractCountryCode(addressComponents) {
+  return addressComponents.filter(component => component.types.includes('country'))[0].short_name
+}
+</script>
+
+<GooglePlacesAutocomplete apiKey={googlePlacesApiKey} class={$$props.class} on:place_changed={onPlaceChanged} {options}
+                          {placeholder} />

--- a/src/components/LocationInput.svelte
+++ b/src/components/LocationInput.svelte
@@ -12,9 +12,6 @@ const options = {
 }
 
 function onPlaceChanged(event) {
-  
-  console.log('place_changed', event.detail) // TEMP
-  
   const place = event.detail.place
   const description = event.detail.text
   dispatch('locationSelected', {

--- a/src/components/LocationInput.svelte
+++ b/src/components/LocationInput.svelte
@@ -12,9 +12,16 @@ const options = {
 }
 
 function onPlaceChanged(event) {
-  const place = event.detail.place
-  const description = event.detail.text
-  dispatch('locationSelected', {
+  const locationData = event.detail
+  if (locationData) {
+    selectLocation(locationData.text, locationData.place)
+  } else {
+    clearLocation()
+  }
+}
+
+function selectLocation(description, place) {
+  dispatch('change', {
     description: description,
     latitude: place.geometry.location.lat(),
     longitude: place.geometry.location.lng(),
@@ -24,6 +31,10 @@ function onPlaceChanged(event) {
 
 function extractCountryCode(addressComponents) {
   return addressComponents.filter(component => component.types.includes('country'))[0].short_name
+}
+
+function clearLocation() {
+  dispatch('change', null)
 }
 </script>
 

--- a/src/components/LocationInput.svelte
+++ b/src/components/LocationInput.svelte
@@ -2,10 +2,10 @@
 import GooglePlacesAutocomplete from '@silintl/svelte-google-places-autocomplete'
 import { createEventDispatcher } from 'svelte'
 
-export let googlePlacesApiKey
 export let placeholder
 
 const dispatch = createEventDispatcher()
+const googlePlacesApiKey = process.env.GOOGLE_PLACES_API_KEY
 const options = {
   fields: ['address_components', 'geometry'],
   types: ['(cities)']

--- a/src/components/RequestListEntry.svelte
+++ b/src/components/RequestListEntry.svelte
@@ -37,7 +37,7 @@ $: origin = request.origin && request.origin.description
     <div class="col-7 col-sm-9">
       <div class="card-body p-1">
         <h3 class="card-title text-truncate">{request.title}</h3>
-        <div class="form-row small">
+        <div class="form-row">
           <div class="col-12 col-sm text-truncate">
             <span class="text-muted small small-caps">To:</span>
             {request.destination.description}

--- a/src/components/RequestListEntry.svelte
+++ b/src/components/RequestListEntry.svelte
@@ -38,11 +38,11 @@ $: origin = request.origin && request.origin.description
       <div class="card-body p-1">
         <h3 class="card-title text-truncate">{request.title}</h3>
         <div class="form-row">
-          <div class="col-12 col-sm text-truncate">
+          <div class="col-12 col-sm text-truncate" title={request.destination.description}>
             <span class="text-muted small small-caps">To:</span>
             {request.destination.description}
           </div>
-          <div class="col-12 col-sm text-truncate">
+          <div class="col-12 col-sm text-truncate" title={origin}>
             <span class="text-muted small small-caps">From:</span>
             {#if origin }
               {origin}

--- a/src/components/RequestListEntry.svelte
+++ b/src/components/RequestListEntry.svelte
@@ -9,6 +9,7 @@ export let request;
 
 $: user = request.createdBy || {}
 $: size = request.size
+$: origin = request.origin && request.origin.description
 </script>
 
 <style>
@@ -26,21 +27,35 @@ $: size = request.size
 }
 </style>
 
-<div class="card request-list-entry h-100" on:click={ () => push(`/requests/${request.id}`) }>
+<div class="card request-list-entry h-100" on:click="{ () => push(`/requests/${request.id}`) }">
   <div class="row no-gutters h-100">
-    <div class="col-1">
+    <div class="col-2 col-sm-1">
       <div class="card-img text-center h-100">
         <RequestImage {request} showSize={false} />
       </div>
     </div>
-    <div class="col">
-      <div class="card-body p-2">
-        <h3 class="card-title d-inline-block">{request.title}</h3>
-        <span class="card-text">| {request.destination.description}</span>
+    <div class="col-7 col-sm-9">
+      <div class="card-body p-1">
+        <h3 class="card-title text-truncate">{request.title}</h3>
+        <div class="form-row small">
+          <div class="col-12 col-sm text-truncate">
+            <span class="text-muted small small-caps">To:</span>
+            {request.destination.description}
+          </div>
+          <div class="col-12 col-sm text-truncate">
+            <span class="text-muted small small-caps">From:</span>
+            {#if origin }
+              {origin}
+            {:else}
+              <i>anywhere</i>
+            {/if}
+          </div>
+        </div>
       </div>
     </div>
-    <div class="col-auto p-2"><SizeIndicator {size} /></div>
-    <div class="col-auto p-2"><UserAvatar {user} small />
+    <div class="col-3 col-sm-2 text-center small">
+      <SizeIndicator {size} /><br />
+      <UserAvatar {user} small />
     </div>
   </div>
 </div>

--- a/src/components/RequestTile.svelte
+++ b/src/components/RequestTile.svelte
@@ -49,19 +49,31 @@ h3.smaller {
     <h3 class="card-title mb-auto" class:smaller>{request.title}</h3>
   </div>
   <div class="card-footer p-2" class:smaller>
-    <div class="row">
+    <div class="form-row">
       <div class="col">
-        <div class="card-text" class:smaller>
-          <span class="text-muted small small-caps">To:</span> {request.destination.description}
+        
+        <div class="d-table-row">
+          <div class="d-table-cell pr-1" class:smaller>
+            <span class="text-muted small small-caps">To:</span>
+          </div>
+          <div class="d-table-cell" class:smaller>
+            {request.destination.description}
+          </div>
         </div>
-        <div class="card-text" class:smaller>
-          <span class="text-muted small small-caps">From:</span>
-          {#if origin }
-            {origin}
-          {:else}
-            <i>anywhere</i>
-          {/if}
+        
+        <div class="d-table-row">
+          <div class="d-table-cell pr-1" class:smaller>
+            <span class="text-muted small small-caps">From:</span>
+          </div>
+          <div class="d-table-cell" class:smaller>
+            {#if origin }
+              {origin}
+            {:else}
+              <i>anywhere</i>
+            {/if}
+          </div>
         </div>
+        
       </div>
       <div class="col-auto"><UserAvatar {user} small /></div>
     </div>

--- a/src/components/RequestTile.svelte
+++ b/src/components/RequestTile.svelte
@@ -15,7 +15,7 @@ $: origin = request.origin && request.origin.description
 
 <style>
 .card-footer.smaller {
-  line-height: 75%;
+  line-height: 1.3;
 }
 h3.smaller {
   font-size: 1.25rem;
@@ -39,6 +39,15 @@ h3.smaller {
 .smaller {
   font-size: 0.9rem;
 }
+.smaller .from-prefix,
+.smaller .to-prefix {
+  display: block;
+}
+
+/* Leave space for the UserAvatar. */
+.to-from-lines { padding-right: 2.1rem; }
+.smaller .to-from-lines { padding-right: inherit; }
+.smaller .from-line { padding-right: 2.1rem;}
 </style>
 
 <div class="card request-tile" on:click={ () => push(`/requests/${request.id}`) }>
@@ -49,33 +58,24 @@ h3.smaller {
     <h3 class="card-title mb-auto" class:smaller>{request.title}</h3>
   </div>
   <div class="card-footer p-2" class:smaller>
-    <div class="form-row">
-      <div class="col">
-        
-        <div class="d-table-row">
-          <div class="d-table-cell pr-1" class:smaller>
-            <span class="text-muted small small-caps">To:</span>
-          </div>
-          <div class="d-table-cell" class:smaller>
-            {request.destination.description}
-          </div>
+    <div class="position-relative">
+      <div class="position-absolute" style="bottom: 0; right: 0;"><UserAvatar {user} small /></div>
+      
+      <div class="to-from-lines">
+        <div class="text-truncate to-line" class:smaller title={request.destination.description}>
+          <span class="text-muted small small-caps to-prefix">To:</span>
+          {request.destination.description}
         </div>
         
-        <div class="d-table-row">
-          <div class="d-table-cell pr-1" class:smaller>
-            <span class="text-muted small small-caps">From:</span>
-          </div>
-          <div class="d-table-cell" class:smaller>
-            {#if origin }
-              {origin}
-            {:else}
-              <i>anywhere</i>
-            {/if}
-          </div>
+        <div class="text-truncate from-line" class:smaller title={origin}>
+          <span class="text-muted small small-caps from-prefix">From:</span>
+          {#if origin }
+            {origin}
+          {:else}
+            <i>anywhere</i>
+          {/if}
         </div>
-        
       </div>
-      <div class="col-auto"><UserAvatar {user} small /></div>
     </div>
   </div>
 </div>

--- a/src/components/RequestTile.svelte
+++ b/src/components/RequestTile.svelte
@@ -10,6 +10,7 @@ export let smaller = false;
 
 $: user = request.createdBy || {}
 $: size = request.size
+$: origin = request.origin && request.origin.description
 </script>
 
 <style>
@@ -32,6 +33,9 @@ h3.smaller {
 .request-tile > .request-image.smaller {
   height: 6rem;
 }
+.small-caps {
+  font-variant: small-caps;
+}
 .smaller {
   font-size: 0.9rem;
 }
@@ -41,14 +45,25 @@ h3.smaller {
   <div class="card-img-top request-image text-center" class:smaller>
     <RequestImage {request} />
   </div>
-  <div class="card-body p-2">
-    <h3 class="card-title" class:smaller>{request.title}</h3>
-    <div class="card-text" class:smaller>{request.destination.description}</div>
+  <div class="card-body d-flex align-items-start flex-column p-2">
+    <h3 class="card-title mb-auto" class:smaller>{request.title}</h3>
   </div>
   <div class="card-footer p-2" class:smaller>
     <div class="row">
-      <div class="col"><UserAvatar {user} small /></div>
-      <div class="col-auto"><a class="pr-1" href="#/requests/{request.id}">View</a></div>
+      <div class="col">
+        <div class="card-text" class:smaller>
+          <span class="text-muted small small-caps">To:</span> {request.destination.description}
+        </div>
+        <div class="card-text" class:smaller>
+          <span class="text-muted small small-caps">From:</span>
+          {#if origin }
+            {origin}
+          {:else}
+            <i>anywhere</i>
+          {/if}
+        </div>
+      </div>
+      <div class="col-auto"><UserAvatar {user} small /></div>
     </div>
   </div>
 </div>

--- a/src/data/gqlQueries.js
+++ b/src/data/gqlQueries.js
@@ -55,12 +55,8 @@ export async function createRequest(request) {
     mutation {
       createPost(input: {
         description: ${json(request.description || '')},
-        destination: {
-          country: ${json(request.destination.country)}
-          description: ${json(request.destination.description)},
-          latitude: ${json(request.destination.latitude)},
-          longitude: ${json(request.destination.longitude)},
-        },
+        destination: ${formatLocationForGql(request.destination)},
+        origin: ${formatLocationForGql(request.origin)},
         orgID: ${json(request.orgID)},
         photoID: ${json(request.photoID || '')},
         size: ${request.size}
@@ -166,6 +162,18 @@ export async function markMessagesAsRead(threadId) {
 
 const json = JSON.stringify
 
+const formatLocationForGql = function (location) {
+  if (location) {
+    return `{
+      country: ${json(location.country)}
+      description: ${json(location.description)},
+      latitude: ${json(location.latitude)},
+      longitude: ${json(location.longitude)},
+    }`
+  }
+  return `null`
+}
+
 const userFields = `
   avatarURL
   email
@@ -185,6 +193,9 @@ const postFields = `
   }
   description
   destination {
+    description
+  }
+  origin {
     description
   }
   id

--- a/src/views/CreateOrUpdateRequest.svelte
+++ b/src/views/CreateOrUpdateRequest.svelte
@@ -30,6 +30,7 @@ const newRequest = {
 
 $: request = $requests.find(({ id }) => id === params.id) || newRequest
 $: isNew = !request.id
+$: originDescription = (request.origin && request.origin.description) || ''
 $: if ($me.organizations && $me.organizations.length > 0) {
   request.viewableBy = $me.organizations[0].id
 }
@@ -64,6 +65,12 @@ async function onSubmit() {
           latitude: request.destination.geometry.location.lat(),
           longitude: request.destination.geometry.location.lng(),
           country: extractCountryCode(request.destination.address_components),
+        },
+        origin: request.origin && {
+          description: request.origin.formatted_address,
+          latitude: request.origin.geometry.location.lat(),
+          longitude: request.origin.geometry.location.lng(),
+          country: extractCountryCode(request.origin.address_components),
         },
         photoID: request.photoID,
         size: request.size,
@@ -116,7 +123,7 @@ async function cancelRequest() {
   
   <div class="form-row form-group">
     <label class="col-12 col-sm-3 col-lg-2 col-form-label-lg">
-      Destination:
+      To:
     </label>
     
     <div class="col">
@@ -135,6 +142,32 @@ async function cancelRequest() {
       {:else}
         <!-- TODO: need to learn how to preload the GPA with existing values while having the value get loaded with the right location object, for now this is readonly  -->
         <input class="form-control form-control-lg" placeholder={request.destination.description} readonly>
+      {/if}
+    </div>
+  </div>
+  
+  <div class="form-row form-group">
+    <label class="col-12 col-sm-3 col-lg-2 col-form-label-lg">
+      From: <br />
+      <small class="text-muted font-italic">(optional)</small>
+    </label>
+    
+    <div class="col">
+      {#if isNew}
+        <div class="form-group">
+          <div class="input-group">
+            <div class="input-group-prepend">
+              <span class="input-group-text">
+                <Icon icon={faMapMarkerAlt} />
+              </span>
+            </div>
+
+            <GooglePlacesAutocomplete bind:value={request.origin} placeholder="Where?" {options} apiKey={process.env.GOOGLE_PLACES_API_KEY} styleClass="form-control form-control-lg" />
+          </div>
+        </div>
+      {:else}
+        <!-- TODO: need to learn how to preload the GPA with existing values while having the value get loaded with the right location object, for now this is readonly  -->
+        <input class="form-control form-control-lg" placeholder={originDescription} readonly>
       {/if}
     </div>
   </div>

--- a/src/views/CreateOrUpdateRequest.svelte
+++ b/src/views/CreateOrUpdateRequest.svelte
@@ -136,7 +136,7 @@ async function cancelRequest() {
               </span>
             </div>
 
-            <GooglePlacesAutocomplete bind:value={request.destination} placeholder="Origin city" {options} apiKey={process.env.GOOGLE_PLACES_API_KEY} styleClass="form-control form-control-lg" />
+            <GooglePlacesAutocomplete bind:value={request.destination} placeholder="Destination city" {options} apiKey={process.env.GOOGLE_PLACES_API_KEY} styleClass="form-control form-control-lg" />
           </div>
         </div>
       {:else}
@@ -162,7 +162,7 @@ async function cancelRequest() {
               </span>
             </div>
 
-            <GooglePlacesAutocomplete bind:value={request.origin} placeholder="Destination city" {options} apiKey={process.env.GOOGLE_PLACES_API_KEY} styleClass="form-control form-control-lg" />
+            <GooglePlacesAutocomplete bind:value={request.origin} placeholder="Origin city" {options} apiKey={process.env.GOOGLE_PLACES_API_KEY} styleClass="form-control form-control-lg" />
           </div>
         </div>
       {:else}

--- a/src/views/CreateOrUpdateRequest.svelte
+++ b/src/views/CreateOrUpdateRequest.svelte
@@ -14,7 +14,6 @@ import { throwError } from '../data/error'
 
 export let params = {} // URL path parameters, provided by router.
 
-let googlePlacesApiKey = process.env.GOOGLE_PLACES_API_KEY
 let imageUrl = ''
 
 const newRequest = {
@@ -124,8 +123,7 @@ function onOriginChanged(event) {
               </span>
             </div>
 
-            <LocationInput class="form-control form-control-lg" {googlePlacesApiKey}
-                           on:change={onDestinationChanged} placeholder="Destination city" />
+            <LocationInput class="form-control form-control-lg" on:change={onDestinationChanged} placeholder="Destination city" />
           </div>
         </div>
       {:else}
@@ -151,8 +149,7 @@ function onOriginChanged(event) {
               </span>
             </div>
 
-            <LocationInput class="form-control form-control-lg" {googlePlacesApiKey}
-                           on:change={onOriginChanged} placeholder="Origin city" />
+            <LocationInput class="form-control form-control-lg" on:change={onOriginChanged} placeholder="Origin city" />
           </div>
         </div>
       {:else}

--- a/src/views/CreateOrUpdateRequest.svelte
+++ b/src/views/CreateOrUpdateRequest.svelte
@@ -80,6 +80,14 @@ async function cancelRequest() {
   
   cancelled()
 }
+
+function onDestinationChanged(event) {
+  request.destination = event.detail
+}
+
+function onOriginChanged(event) {
+  request.origin = event.detail
+}
 </script>
 
 <style>
@@ -117,7 +125,7 @@ async function cancelRequest() {
             </div>
 
             <LocationInput class="form-control form-control-lg" {googlePlacesApiKey}
-                           on:locationSelected="{event => request.destination = event.detail}" placeholder="Destination city" />
+                           on:change={onDestinationChanged} placeholder="Destination city" />
           </div>
         </div>
       {:else}
@@ -144,7 +152,7 @@ async function cancelRequest() {
             </div>
 
             <LocationInput class="form-control form-control-lg" {googlePlacesApiKey}
-                           on:locationSelected="{event => request.origin = event.detail}" placeholder="Origin city" />
+                           on:change={onOriginChanged} placeholder="Origin city" />
           </div>
         </div>
       {:else}

--- a/src/views/CreateOrUpdateRequest.svelte
+++ b/src/views/CreateOrUpdateRequest.svelte
@@ -14,6 +14,7 @@ import { throwError } from '../data/error'
 
 export let params = {} // URL path parameters, provided by router.
 
+let googlePlacesApiKey = process.env.GOOGLE_PLACES_API_KEY
 let imageUrl = ''
 
 const newRequest = {
@@ -115,7 +116,7 @@ async function cancelRequest() {
               </span>
             </div>
 
-            <LocationInput class="form-control form-control-lg" googlePlacesApiKey={process.env.GOOGLE_PLACES_API_KEY}
+            <LocationInput class="form-control form-control-lg" {googlePlacesApiKey}
                            on:locationSelected="{event => request.destination = event.detail}" placeholder="Destination city" />
           </div>
         </div>
@@ -142,7 +143,7 @@ async function cancelRequest() {
               </span>
             </div>
 
-            <LocationInput class="form-control form-control-lg" googlePlacesApiKey={process.env.GOOGLE_PLACES_API_KEY}
+            <LocationInput class="form-control form-control-lg" {googlePlacesApiKey}
                            on:locationSelected="{event => request.origin = event.detail}" placeholder="Origin city" />
           </div>
         </div>

--- a/src/views/CreateOrUpdateRequest.svelte
+++ b/src/views/CreateOrUpdateRequest.svelte
@@ -199,7 +199,7 @@ function onOriginChanged(event) {
     
     {#if !isNew}
       <div class="col-auto text-center">
-        <button on:click|preventDefault={cancelRequest} class="btn btn-outline-danger">
+        <button type="button" on:click={cancelRequest} class="btn btn-outline-danger">
           <Icon icon={faTrash} /> Delete
         </button>
       </div>

--- a/src/views/CreateOrUpdateRequest.svelte
+++ b/src/views/CreateOrUpdateRequest.svelte
@@ -127,7 +127,7 @@ function onOriginChanged(event) {
           </div>
         </div>
       {:else}
-        <!-- TODO: need to learn how to preload the GPA with existing values while having the value get loaded with the right location object, for now this is readonly  -->
+        <!-- TODO: Need to figure out how to make the locations editable. For now this is readonly. -->
         <input class="form-control form-control-lg" placeholder={request.destination.description} readonly>
       {/if}
     </div>
@@ -153,7 +153,7 @@ function onOriginChanged(event) {
           </div>
         </div>
       {:else}
-        <!-- TODO: need to learn how to preload the GPA with existing values while having the value get loaded with the right location object, for now this is readonly  -->
+        <!-- TODO: Need to figure out how to make the locations editable. For now this is readonly. -->
         <input class="form-control form-control-lg" placeholder={originDescription} readonly>
       {/if}
     </div>

--- a/src/views/CreateOrUpdateRequest.svelte
+++ b/src/views/CreateOrUpdateRequest.svelte
@@ -20,7 +20,7 @@ let imageUrl = ''
 // so we could use house addresses, lat/long, etc...no need for restrictions.  See 
 // (https://developers.google.com/places/supported_types#table3 && https://github.com/beyonk-adventures/svelte-googlemaps/blob/master/src/GooglePlacesAutocomplete.svelte#L15)
 const options = {
-  types: []
+  types: ['(cities)']
 }
 
 const newRequest = {
@@ -136,7 +136,7 @@ async function cancelRequest() {
               </span>
             </div>
 
-            <GooglePlacesAutocomplete bind:value={request.destination} placeholder="Where?" {options} apiKey={process.env.GOOGLE_PLACES_API_KEY} styleClass="form-control form-control-lg" />
+            <GooglePlacesAutocomplete bind:value={request.destination} placeholder="Origin city" {options} apiKey={process.env.GOOGLE_PLACES_API_KEY} styleClass="form-control form-control-lg" />
           </div>
         </div>
       {:else}
@@ -162,7 +162,7 @@ async function cancelRequest() {
               </span>
             </div>
 
-            <GooglePlacesAutocomplete bind:value={request.origin} placeholder="Where?" {options} apiKey={process.env.GOOGLE_PLACES_API_KEY} styleClass="form-control form-control-lg" />
+            <GooglePlacesAutocomplete bind:value={request.origin} placeholder="Destination city" {options} apiKey={process.env.GOOGLE_PLACES_API_KEY} styleClass="form-control form-control-lg" />
           </div>
         </div>
       {:else}

--- a/src/views/CreateOrUpdateRequest.svelte
+++ b/src/views/CreateOrUpdateRequest.svelte
@@ -193,7 +193,7 @@ async function cancelRequest() {
     
     {#if !isNew}
       <div class="col-auto text-center">
-        <button on:click={cancelRequest} class="btn btn-outline-danger">
+        <button on:click|preventDefault={cancelRequest} class="btn btn-outline-danger">
           <Icon icon={faTrash} /> Delete
         </button>
       </div>

--- a/src/views/Request.svelte
+++ b/src/views/Request.svelte
@@ -15,6 +15,7 @@ $: request = $requests.find(({ id }) => id === params.id) || {}
 $: requester = request.createdBy || {}
 $: isMine = $me.id && (requester.id === $me.id) // Check $me.id first to avoid `undefined === undefined`
 $: destination = request.destination && request.destination.description || ''
+$: origin = request.origin && request.origin.description || ''
 
 function goToConversation(conversationId) {
   replace(`/requests/${params.id}/conversation/${conversationId}`)
@@ -58,7 +59,12 @@ function goToConversation(conversationId) {
       <div class="row">
         <div class="col">
           <h3 class="card-title">{ request.title || ''}</h3>
-          <p>Deliver to <u>{ destination }</u></p>
+          <p>
+            Deliver to <u>{ destination }</u>
+            {#if origin }
+              <br />from <u>{ origin }</u>
+            {/if}
+          </p>
         </div>
         <div class="col-auto">
           <div class="user-avatar-container text-center mb-2">

--- a/src/views/Requests.svelte
+++ b/src/views/Requests.svelte
@@ -159,7 +159,7 @@ function searchForText(searchText) {
           {#if showAsList }
             <div class="col-12 my-1"><RequestListEntry {request} /></div>
           {:else}
-            <div class="col-6 mb-1 my-sm-1 col-md-6 col-lg-4 col-xl-3"><RequestTile {request} /></div>
+            <div class="col-6 mb-1 my-sm-1 col-md-6 col-lg-4"><RequestTile {request} /></div>
           {/if}
         {/each}
         
@@ -172,7 +172,7 @@ function searchForText(searchText) {
         <a href="#/requests/new" class="btn btn-success btn-sm"><span style="font-size: larger">+</span> Make a request</a>
       </div>
       
-      <div class:d-md-block={!showAsList} class="d-none col-6 mb-1 my-sm-1 col-md-6 col-lg-4 col-xl-3"><NewRequestTile /></div>
+      <div class:d-md-block={!showAsList} class="d-none col-6 mb-1 my-sm-1 col-md-6 col-lg-4"><NewRequestTile /></div>
     </div>
   </div>
 </div>

--- a/src/views/Requests.svelte
+++ b/src/views/Requests.svelte
@@ -141,7 +141,7 @@ function searchForText(searchText) {
       </div>
     </div>
   </div>
-  <div class="col col-sm-10 offset-sm-1 col-md offset-md-0">
+  <div class="col">
     <div class="form-row align-items-stretch">
       <div class="col-12">
         <div class="input-group mb-2">

--- a/src/views/Requests.svelte
+++ b/src/views/Requests.svelte
@@ -159,7 +159,7 @@ function searchForText(searchText) {
           {#if showAsList }
             <div class="col-12 my-1"><RequestListEntry {request} /></div>
           {:else}
-            <div class="col-6 mb-1 my-sm-1 col-md-6 col-lg-4"><RequestTile {request} /></div>
+            <div class="col-6 my-1 col-lg-4"><RequestTile {request} /></div>
           {/if}
         {/each}
         


### PR DESCRIPTION
**Added:**
- Allow providing an origin ("from") for requests
- Show "To" and "From" on the requests page (list and grid)
- Show origin on request details page

**Changed:**
- Limit location results to cities
- Reduce from 4 to 3 tiles wide at full width grid view (to reduce truncation of locations)
- Switch from [@beyonk/svelte-googlemaps](https://github.com/beyonk-adventures/svelte-googlemaps) to new [@silintl/svelte-google-places-autocomplete](https://github.com/silinternational/svelte-google-places-autocomplete) library