### PR TITLE
Get posts' `photoID` to avoid losing the photo on updates

### DIFF
--- a/src/data/gqlQueries.js
+++ b/src/data/gqlQueries.js
@@ -227,6 +227,7 @@ const postFields = `
   photo {
     url
   }
+  photoID
   potentialProviders {
     id
     nickname


### PR DESCRIPTION
Needs to be deployed **AFTER** the API change that provides the `photoID` field for posts:
https://github.com/silinternational/wecarry-api/pull/245