### PR TITLE
Events: use valueless query string params for toggles

### DIFF
--- a/src/components/EventFilters.svelte
+++ b/src/components/EventFilters.svelte
@@ -33,7 +33,7 @@ function onLocationInput(event) {
 
 function onMyEventsChange(event) {
   if (event.detail) {
-    setFilters({ participating: 1 })
+    setFilters({ participating: null })
     
     filteredMeetingsByMine()
   } else {

--- a/src/components/RequestFilters.svelte
+++ b/src/components/RequestFilters.svelte
@@ -34,14 +34,14 @@ function onEventChange(domEvent) {
   const eventId = domEvent.detail
   if (eventId) {
     setFilters({
-      destination: null,
+      destination: false,
       event: eventId,
     })
   
     const eventName = $events.find(({ id }) => id === eventId).name
     filteredRequestsByEvent(eventName)
   } else {
-    setFilters({ event: null })
+    removeFilter('event')
   }
 }
 
@@ -49,7 +49,7 @@ function onDestinationInput(event) {
   const query = event.detail
   setFilters({
     destination: query,
-    event: null,
+    event: false,
   })
 
   filteredRequestsByDestination(query)
@@ -72,9 +72,9 @@ function onKeywordInput(event) {
 function onMyCommitmentsChange(event) {
   if (event.detail) {
     setFilters({
-      creator: null,
+      creator: false,
       provider: $me.id,
-      size: null,
+      size: false,
     })
     filteredRequestsByProviding()
   } else {
@@ -86,8 +86,8 @@ function onMyRequestsChange(event) {
   if (event.detail) {
     setFilters({
       creator: $me.id,
-      provider: null,
-      size: null,
+      provider: false,
+      size: false,
     })
     filteredRequestsByMine()
   } else {

--- a/src/data/eventFiltering.js
+++ b/src/data/eventFiltering.js
@@ -4,9 +4,9 @@ import { updateQueryString } from './url'
 /** NOTE: This should clear all values used by `populateEventFilterFrom()` */
 export function clearEventFilter() {
   updateQueryString({
-    location: null,
-    participating: null,
-    search: null,
+    location: false,
+    participating: false,
+    search: false,
   })
 }
 
@@ -20,10 +20,10 @@ export function populateEventFilterFrom(queryStringData, me) {
       value: queryStringData.location,
     },
     participating: {
-      active: !! queryStringData.participating,
+      active: queryStringData.hasOwnProperty('participating'),
       label: 'Only my events',
       isMatch: event => isParticipant(me, event),
-      value: queryStringData.participating,
+      value: queryStringData.hasOwnProperty('participating'),
     },
     search: {
       active: !! queryStringData.search,

--- a/src/data/filtering.js
+++ b/src/data/filtering.js
@@ -45,7 +45,7 @@ export function isItemInList(item, items) {
  */
 export function removeFilter(name) {
   const updates = {}
-  updates[name] = null
+  updates[name] = false
   updateQueryString(updates)
 }
 
@@ -55,14 +55,21 @@ export function removeFilter(name) {
  * Example:
  * `setFilters({ size: 'tiny' })`
  *
- * To remove some other filter(s) at the same time, send `null` for the filter(s) to be removed.
+ * To remove some other filter(s) at the same time, send `false` for the filter(s) to be removed.
  *
  * Example:
  * ```
  * setFilters({
  *   creator: $me.id,
- *   provider: null,
+ *   provider: false,
  * })
+ * ```
+ *
+ * To add a parameter with no value (simply using its presence/absence as a sort of toggle), send `null`.
+ *
+ * Example:
+ * ```
+ * setFilters({ participant: null })
  * ```
  *
  * @param {Object} updates

--- a/src/data/requestFiltering.js
+++ b/src/data/requestFiltering.js
@@ -5,13 +5,13 @@ import { updateQueryString } from './url'
 /** NOTE: This should clear all values used by `populateRequestFilterFrom()` */
 export function clearRequestFilter() {
   updateQueryString({
-    creator: null,
-    destination: null,
-    event: null,
-    origin: null,
-    search: null,
-    provider: null,
-    size: null,
+    creator: false,
+    destination: false,
+    event: false,
+    origin: false,
+    search: false,
+    provider: false,
+    size: false,
   })
 }
 

--- a/src/data/url.js
+++ b/src/data/url.js
@@ -3,17 +3,21 @@ import { get } from 'svelte/store'
 import qs from 'qs'
 
 export function updateQueryString(updates) {
-  let queryStringData = qs.parse(get(querystring))
+  let queryStringData = qs.parse(get(querystring), { strictNullHandling: true })
 
   for (const key in updates) {
     const value = updates[key]
-    if (value) {
+    if (value === null) {
+      // For mere present/absent parameters, we can use `null`, which causes `qs.stringify()` (if using
+      // `strictNullHandling`) to omit the = sign and value.
+      queryStringData[key] = null
+    } else if (value) {
       queryStringData[key] = value
     } else if (queryStringData.hasOwnProperty(key)) {
       delete queryStringData[key]
     }
   }
 
-  const newQueryString = qs.stringify(queryStringData)
+  const newQueryString = qs.stringify(queryStringData, { strictNullHandling: true })
   newQueryString ? push(get(location) + '?' + newQueryString) : push(get(location))
 }

--- a/src/views/Requests.svelte
+++ b/src/views/Requests.svelte
@@ -24,7 +24,7 @@ $: requestFilter = populateRequestFilterFrom(queryStringData, $me, $events)
 $: showAsList = queryStringData.hasOwnProperty('list')
 
 function viewAsGrid() {
-  updateQueryString({ list: null })
+  updateQueryString({ list: false })
 
   viewedRequestsAsGrid()
 }

--- a/src/views/Requests.svelte
+++ b/src/views/Requests.svelte
@@ -30,7 +30,7 @@ function viewAsGrid() {
 }
 
 function viewAsList() {
-  updateQueryString({ list: 1 })
+  updateQueryString({ list: null })
 
   viewedRequestsAsList()
 }


### PR DESCRIPTION
The `qs` library we're using lets us add valueless query string parameters, but to do so requires that we use `null` for their value and make use of the `strictNullHandling` option, both when writing and when reading data to/from the query string.

That, in turn, required that I switch to some other "falsy" value for removing query string parameters, so I went with `false` itself.

I eventually hope to manage our query string data via a Svelte store, which will let us shield the rest of our code from needing to know what value to use to remove a query string parameter (since they would then be able to simply call a "remove" method of some sort).