### PR TITLE
Add region to request filtering

### DIFF
--- a/src/components/CreateOrUpdateRequest.svelte
+++ b/src/components/CreateOrUpdateRequest.svelte
@@ -132,7 +132,7 @@ function onWeightChanged(event) {
     <div class="col">
       <div class="form-group">
         <LocationInput class="form-control form-control-lg" on:change={onDestinationChanged}
-                       placeholder="Destination city" location={request.destination} />
+                       placeholder="Destination" location={request.destination} />
       </div>
     </div>
   </div>
@@ -146,7 +146,7 @@ function onWeightChanged(event) {
     <div class="col">
       <div class="form-group">
         <LocationInput class="form-control form-control-lg" on:change={onOriginChanged}
-                       placeholder="Origin city" location={request.origin} />
+                       placeholder="Origin" location={request.origin} />
       </div>
     </div>
   </div>

--- a/src/components/LocationInput.svelte
+++ b/src/components/LocationInput.svelte
@@ -7,13 +7,13 @@ import { faMapMarkerAlt } from '@fortawesome/free-solid-svg-icons'
 export let placeholder
 export let location = null
 
-$: description = (location && location.description) || ''
+$: description = location?.description || ''
 
 const dispatch = createEventDispatcher()
 const googlePlacesApiKey = process.env.GOOGLE_PLACES_API_KEY
 const options = {
   fields: ['address_components', 'geometry'],
-  types: ['(cities)']
+  types: ['(regions)']
 }
 
 function onPlaceChanged(event) {
@@ -31,11 +31,31 @@ function selectLocation(description, place) {
     latitude: place.geometry.location.lat(),
     longitude: place.geometry.location.lng(),
     country: extractCountryCode(place.address_components),
+    state: extractState(place.address_components),
+    county: extractCounty(place.address_components),
+    locality: extractLocality(place.address_components),
+    sublocality: extractSublocality(place.address_components),
   })
 }
 
 function extractCountryCode(addressComponents) {
   return addressComponents.filter(component => component.types.includes('country'))[0].short_name
+}
+
+function extractState(addressComponents) {
+  return addressComponents.filter(component => component.types.includes('administrative_area_level_1'))[0]?.short_name
+}
+
+function extractCounty(addressComponents) {
+  return addressComponents.filter(component => component.types.includes('administrative_area_level_2'))[0]?.short_name
+}
+
+function extractLocality(addressComponents) {
+  return addressComponents.filter(component => component.types.includes('locality'))[0]?.short_name
+}
+
+function extractSublocality(addressComponents) {
+  return addressComponents.filter(component => component.types.includes('sublocality'))[0]?.short_name
 }
 
 function clearLocation() {

--- a/src/components/RequestFilters.svelte
+++ b/src/components/RequestFilters.svelte
@@ -154,9 +154,9 @@ function resetFilters() {
     <ToggleFilter on:change={onMyRequestsChange} active={onlyMyRequests} label="Only my requests" />
     <ToggleFilter on:change={onMyCommitmentsChange} active={onlyMyCommitments} label="Only my commitments" />
     <hr />
-    <LocationFilter title="From" placeholder="Origin city" location={origin} on:change={onOriginChange}/>
+    <LocationFilter title="From" placeholder="Origin" location={origin} on:change={onOriginChange}/>
     <hr />
-    <LocationFilter title="To" placeholder="Destination city" location={destination} on:change={onDestinationChange}/>
+    <LocationFilter title="To" placeholder="Destination" location={destination} on:change={onDestinationChange}/>
     {#if $events.length }
       <p class="mb-2 text-center text-muted">– or –</p>
       <EventFilter events={$events} {eventId} on:change={onEventChange} />

--- a/src/components/RequestFilters.svelte
+++ b/src/components/RequestFilters.svelte
@@ -55,6 +55,10 @@ function onDestinationChange(event) {
     $goto(setFilters( {
       toDescription: location.description,
       toCountry: location.country,
+      toState: location.state,
+      toCounty: location.county,
+      toLocality: location.locality,
+      toSublocality: location.sublocality,
       toLatitude: location.latitude,
       toLongitude: location.longitude,
       event: false,
@@ -72,6 +76,10 @@ function onOriginChange(event) {
     $goto(setFilters( {
       fromDescription: location.description,
       fromCountry: location.country,
+      fromState: location.state,
+      fromCounty: location.county,
+      fromLocality: location.locality,
+      fromSublocality: location.sublocality,
       fromLatitude: location.latitude,
       fromLongitude: location.longitude,
     }))

--- a/src/data/filtering.js
+++ b/src/data/filtering.js
@@ -61,6 +61,10 @@ export function removeFilter(name) {
     updates = {
       toDescription: false,
       toCountry: false,
+      toState: false,
+      toCounty: false,
+      toLocality: false,
+      toSublocality: false,
       toLatitude: false,
       toLongitude: false,
     }
@@ -68,6 +72,10 @@ export function removeFilter(name) {
     updates = {
       fromDescription: false,
       fromCountry: false,
+      fromState: false,
+      fromCounty: false,
+      fromLocality: false,
+      fromSublocality: false,
       fromLatitude: false,
       fromLongitude: false,
     }

--- a/src/data/requestFiltering.js
+++ b/src/data/requestFiltering.js
@@ -103,7 +103,7 @@ function matchByRegion (location, requestLocation) {
   if (location.sublocality || location.locality || location.county) {
     return isNear(location, requestLocation)
   } else if (location.state) {
-    return requestLocation.description.includes(location.state)
+    return requestLocation.description.includes(location.state)  || requestLocation.description.includes(location.description)
   } else if (location.country) {
     return requestLocation.description.includes(location.country) || requestLocation.description.includes(location.description)
   }

--- a/src/data/requestFiltering.js
+++ b/src/data/requestFiltering.js
@@ -8,10 +8,18 @@ export function clearRequestFilter() {
     creator: false,
     toDescription: false,
     toCountry: false,
+    toState: false,
+    toCounty: false,
+    toLocality: false,
+    toSublocality: false,
     toLatitude: false,
     toLongitude: false,
     fromDescription: false,
     fromCountry: false,
+    fromState: false,
+    fromCounty: false,
+    fromLocality: false,
+    fromSublocality: false,
     fromLatitude: false,
     fromLongitude: false,
     event: false,
@@ -26,12 +34,20 @@ export function populateRequestFilterFrom(queryStringData, me, events) {
   let destination = queryStringData.toDescription && {
     description: queryStringData.toDescription,
     country: queryStringData.toCountry,
+    state: queryStringData.toState,
+    county: queryStringData.toCounty,
+    locality: queryStringData.toLocality,
+    sublocality: queryStringData.toSublocality,
     latitude: Number(queryStringData.toLatitude),
     longitude: Number(queryStringData.toLongitude),
   }
   let origin = queryStringData.fromDescription && {
     description: queryStringData.fromDescription,
     country: queryStringData.fromCountry,
+    state: queryStringData.fromState,
+    county: queryStringData.fromCounty,
+    locality: queryStringData.fromLocality,
+    sublocality: queryStringData.fromSublocality,
     latitude: Number(queryStringData.fromLatitude),
     longitude: Number(queryStringData.fromLongitude),
   }
@@ -46,7 +62,7 @@ export function populateRequestFilterFrom(queryStringData, me, events) {
     destination: {
       active: !! queryStringData.toDescription,
       label: labelFor('destination', queryStringData.toDescription),
-      isMatch: request => isNear(destination, request.destination),
+      isMatch: request => matchByRegion(destination, request.destination),
       value: destination,
     },
     event: {
@@ -58,7 +74,7 @@ export function populateRequestFilterFrom(queryStringData, me, events) {
     origin: {
       active: !! queryStringData.fromDescription,
       label: labelFor('origin', queryStringData.fromDescription),
-      isMatch: request => isNear(origin, request.origin),
+      isMatch: request => matchByRegion(origin, request.origin),
       value: origin,
     },
     requestSearch: {
@@ -79,6 +95,17 @@ export function populateRequestFilterFrom(queryStringData, me, events) {
       isMatch: request => includedInSizeSelection(request.size, queryStringData.size),
       value: queryStringData.size,
     },
+  }
+}
+
+function matchByRegion (location, requestLocation) {
+  if (!location || !requestLocation) return true
+  if (location.sublocality || location.locality || location.county) {
+    return isNear(location, requestLocation)
+  } else if (location.state) {
+    return requestLocation.description.includes(location.state)
+  } else if (location.country) {
+    return requestLocation.description.includes(location.country) || requestLocation.description.includes(location.description)
   }
 }
 
@@ -123,6 +150,10 @@ export function removeRequestFilter(name) {
     return setFilters({
       toDescription: false,
       toCountry: false,
+      toState: false,
+      toCounty: false,
+      toLocality: false,
+      toSublocality: false,
       toLatitude: false,
       toLongitude: false,
     })
@@ -132,6 +163,10 @@ export function removeRequestFilter(name) {
     return setFilters({
       fromDescription: false,
       fromCountry: false,
+      fromState: false,
+      fromCounty: false,
+      fromLocality: false,
+      fromSublocality: false,
       fromLatitude: false,
       fromLongitude: false,
     })

--- a/src/data/url.js
+++ b/src/data/url.js
@@ -4,8 +4,7 @@ export function updateQueryString(updates) {
   const querystring = window.location.search
   let queryStringData = qs.parse(querystring, { ignoreQueryPrefix: true, strictNullHandling: true })
 
-  for (const key in updates) {
-    const value = updates[key]
+  for (const [key, value] of Object.entries(updates)) {
     if (value === null) {
       // For mere present/absent parameters, we can use `null`, which causes `qs.stringify()` (if using
       // `strictNullHandling`) to omit the = sign and value.


### PR DESCRIPTION
- changed autocomplete options type to regions
- added filtering properties for:
  - locality
  - sublocality
  - administrative_area_level_1
  - administrative_area_level_2
- filter requests by region if not within 100km
- remove cities from search field placeholder
![Screen Shot 2021-07-07 at 11 30 57 AM](https://user-images.githubusercontent.com/70765247/124789495-57317400-df18-11eb-88c0-12406658bf52.png)
