### PR TITLE
migrate CreateRequest and UpdateRequest to REST

### DIFF
--- a/src/components/CreateOrUpdateRequest.svelte
+++ b/src/components/CreateOrUpdateRequest.svelte
@@ -32,7 +32,7 @@ $: if ($me.organizations && $me.organizations.length > 0) {
 
 function initializeUpdates(requestBeingEdited) {
   request = Object.assign({}, requestBeingEdited)
-  request.needed_before = request.needed_before?.split("T")[0] || ''
+  request.needed_before = request.needed_before?.split("T")[0] || null
 }
 
 function assertHas(value, errorMessage) {
@@ -52,14 +52,14 @@ async function onSubmit() {
 
   if (isNew) {
     await create({
-        orgID: request.viewableBy,
+        org_id: request.viewableBy,
         title: request.title,
         description: request.description,
         destination: request.destination,
         kilograms: request.kilograms,
-        neededBefore: request.needed_before,
+        needed_before: request.needed_before && `${request.needed_before}T00:00:00Z`,
         origin: request.origin,
-        photoID: request.photo.id,
+        photo_id: request.photo?.id,
         size: request.size,
         visibility: request.visibility,
     })

--- a/src/components/CreateOrUpdateRequest.svelte
+++ b/src/components/CreateOrUpdateRequest.svelte
@@ -32,7 +32,6 @@ $: if ($me.organizations && $me.organizations.length > 0) {
 
 function initializeUpdates(requestBeingEdited) {
   request = Object.assign({}, requestBeingEdited)
-  request.needed_before = request.needed_before?.split("T")[0] || null
 }
 
 function assertHas(value, errorMessage) {
@@ -57,7 +56,7 @@ async function onSubmit() {
         description: request.description,
         destination: request.destination,
         kilograms: request.kilograms,
-        needed_before: request.needed_before && `${request.needed_before}T00:00:00Z`,
+        needed_before: request.needed_before,
         origin: request.origin,
         photo_id: request.photo?.id,
         size: request.size,

--- a/src/data/api.js
+++ b/src/data/api.js
@@ -12,13 +12,13 @@ export const DELETE = async (uri, body) => await wrappedFetch('delete', uri, bod
 export async function wrappedFetch(method, url, body) {
   const headers = {
     authorization: getAuthzHeader(),
-    'content-type': 'application/json',
   }
 
   // when dealing with FormData, i.e., when uploading files, allow the browser to set the request up
   // so boundary information is built properly.
-  if (body instanceof FormData) {
-    delete headers['content-type']
+  if (!(body instanceof FormData)) {
+    headers['content-type'] = 'application/json'
+    body = JSON.stringify(body)
   }
 
   // reminder: fetch does not throw exceptions for non-200 responses (https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch)
@@ -58,11 +58,7 @@ export async function wrappedFetch(method, url, body) {
 }
 
 export async function gql(query) {
-  const body = JSON.stringify({
-    query
-  })
-
-  const response = await wrappedFetch('post', 'gql', body)
+  const response = await wrappedFetch('post', 'gql', { query })
 
   if (response.errors) {
     throwError(response.errors[0].message)

--- a/src/data/gqlQueries.js
+++ b/src/data/gqlQueries.js
@@ -73,8 +73,6 @@ export async function createRequest(request) {
 export async function updateRequest(request) {
   // TODO: When API is updated to erase values when we send `null`, update `|| something` to `|| null`
 
-  const neededBefore = request.needed_before?.split("T")[0] || null
-
   const response = await gql(`
     mutation {
       request:updateRequest(input: {
@@ -82,7 +80,7 @@ export async function updateRequest(request) {
         destination: ${formatLocationForGql(request.destination)},
         kilograms: ${json(request.kilograms)},
         id: ${json(request.id)},
-        neededBefore: ${json(neededBefore)},
+        neededBefore: ${json(request.neededBefore || null)},
         origin: ${formatLocationForGql(request.origin)},
         photoID: ${json(request.photoID || null)},
         size: ${request.size},

--- a/src/data/requests.js
+++ b/src/data/requests.js
@@ -1,6 +1,5 @@
-import { GET, POST } from './api'
+import { GET, POST, PUT } from './api'
 import {
-  updateRequest,
   cancelRequest,
   offerToProvide,
   acceptOfferToProvide,
@@ -59,8 +58,8 @@ export async function create(request) {
 }
 
 export async function update(request) {
-  request.photo_id = request.photo_id
-  const updatedRequest = await updateRequest(request)
+  request.photo_id = request.photo?.id
+  const updatedRequest = await PUT(`requests/${request.id}`, request)
 
   requests.update(currentRequests => {
     const i = currentRequests.findIndex(({ id }) => id === updatedRequest.id)

--- a/src/data/requests.js
+++ b/src/data/requests.js
@@ -1,8 +1,6 @@
-import { GET } from './api'
+import { GET, POST } from './api'
 import {
-  createRequest,
   updateRequest,
-  getRequests,
   cancelRequest,
   offerToProvide,
   acceptOfferToProvide,
@@ -30,7 +28,7 @@ async function loadRequests() {
   try {
     loading.set(true)
 
-    const currentRequests = await GET('/requests')
+    const currentRequests = await GET('requests')
 
     requests.set(currentRequests)
   } catch (e) {
@@ -46,7 +44,7 @@ export async function getOneRequest(id) {
   try {
     loading.set(true)
 
-    return await GET(`/requests/${id}`)
+    return await GET(`requests/${id}`)
   } catch (e) {
     throw e
   } finally {
@@ -55,7 +53,7 @@ export async function getOneRequest(id) {
 }
 
 export async function create(request) {
-  const newRequest = await createRequest(request)
+  const newRequest = await POST('requests', request)
 
   requests.update(currentRequests => [newRequest, ...currentRequests])
 }


### PR DESCRIPTION
NOTE: backend has been changed to output `needed_before` as a simple date, just as it was in the GQL query. This solves some issues with interfacing with the date input component.