### PR TITLE
remove image padding from RequestCard and other touch ups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@rollup/plugin-node-resolve": "^11.2.0",
         "@roxi/routify": "^2.15.1",
         "@silintl/svelte-google-places-autocomplete": "^1.1.1",
-        "@silintl/ui-components": "^2.2.0",
+        "@silintl/ui-components": "^2.2.1",
         "bootstrap": "^4.4.1",
         "date-fns": "^2.12.0",
         "fa-svelte": "^3.1.0",
@@ -2430,9 +2430,9 @@
       "dev": true
     },
     "node_modules/@silintl/ui-components": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@silintl/ui-components/-/ui-components-2.2.0.tgz",
-      "integrity": "sha512-DlXESGLYwdozIddiIff5UbmJJiRZjNWvXjWH308YqqX5pXPImEjZZU/EE4YWw2WMBX/ds+FP4EiHVunpw3dtXA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@silintl/ui-components/-/ui-components-2.2.1.tgz",
+      "integrity": "sha512-ye6AkncX4V40pV5uoOo5GZrAbN2p5A8cdk/7KGztdgk3mOBIZIOEBLnPu7py8O0TOFxRb8Jxw55PhykYgmwZMA==",
       "dev": true,
       "peerDependencies": {
         "@roxi/routify": "^2.x",
@@ -11474,9 +11474,9 @@
       "dev": true
     },
     "@silintl/ui-components": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@silintl/ui-components/-/ui-components-2.2.0.tgz",
-      "integrity": "sha512-DlXESGLYwdozIddiIff5UbmJJiRZjNWvXjWH308YqqX5pXPImEjZZU/EE4YWw2WMBX/ds+FP4EiHVunpw3dtXA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@silintl/ui-components/-/ui-components-2.2.1.tgz",
+      "integrity": "sha512-ye6AkncX4V40pV5uoOo5GZrAbN2p5A8cdk/7KGztdgk3mOBIZIOEBLnPu7py8O0TOFxRb8Jxw55PhykYgmwZMA==",
       "dev": true,
       "requires": {}
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "date-fns": "^2.12.0",
         "fa-svelte": "^3.1.0",
         "jquery": "^3.5.1",
+        "material-components-web": "^10.0.0",
         "npm-run-all": "^4.1.5",
         "popper.js": "^1.16.1",
         "postcss": "^8.2.13",
@@ -1456,7 +1457,6 @@
       "resolved": "https://registry.npmjs.org/@material/animation/-/animation-10.0.0.tgz",
       "integrity": "sha512-5e8e+W+n105rfSTRI5Mfmh9VMqzNG8+OhxjfDr7k0lYCfjbkT8LsAInonC5EotJzcaxD0vtDUqRqdW8xKIXNWg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^1.9.3"
       }
@@ -1466,7 +1466,6 @@
       "resolved": "https://registry.npmjs.org/@material/auto-init/-/auto-init-10.0.0.tgz",
       "integrity": "sha512-Deawx+0P7D7A6kCeYcG40sM+pi3O1qAp838fu16Rupy6ZdZ4z3fXQbcHXq4ZQNysRxIdC6S7DjJ/VI340HI+mA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/base": "^10.0.0",
         "tslib": "^1.9.3"
@@ -1477,7 +1476,6 @@
       "resolved": "https://registry.npmjs.org/@material/banner/-/banner-10.0.0.tgz",
       "integrity": "sha512-USIk8WIFHLGafjxTsMjNJf8AsRdAvI+XZjEKkPwvpqgFcBLgDa7rRVO8YsgnXUdcqq3hitAo+w1NbNMU2pogDg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/base": "^10.0.0",
         "@material/button": "^10.0.0",
@@ -1496,7 +1494,6 @@
       "resolved": "https://registry.npmjs.org/@material/base/-/base-10.0.0.tgz",
       "integrity": "sha512-PQWNSsNYVvMcWKsRFHgs5JjsHuv6cTogdlp9uhx5ChdLNCkflpXlMKJ7aYfcl56fdLntWQbxXowLh1JAfrTrmg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^1.9.3"
       }
@@ -1506,7 +1503,6 @@
       "resolved": "https://registry.npmjs.org/@material/button/-/button-10.0.0.tgz",
       "integrity": "sha512-OHIJtlyM+U+MqvPm0N0y9kHf+SFS0I7zE520MulQJywgZhHmU+mz2kwgy+tVxOTceVglQzRZP3KkrwUkf4U0bg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/density": "^10.0.0",
         "@material/dom": "^10.0.0",
@@ -1525,7 +1521,6 @@
       "resolved": "https://registry.npmjs.org/@material/card/-/card-10.0.0.tgz",
       "integrity": "sha512-IwdmUdrMDKb27K6xUhRSafPNbrAmcrPSxM3E8ad1Hk55+9O8Tl9SnGfOQGNtocGa8O7qFr8jsiqdIrxJN85VEA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/dom": "^10.0.0",
         "@material/elevation": "^10.0.0",
@@ -1541,7 +1536,6 @@
       "resolved": "https://registry.npmjs.org/@material/checkbox/-/checkbox-10.0.0.tgz",
       "integrity": "sha512-aZc8KLo+yT15tnEpJWBvqJhUFEVqAKs56DGC8PaKfwfJJMVS0D4Hek61cpl4Jthv6j5eduvpiZ/2DRE8D530Hg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -1559,7 +1553,6 @@
       "resolved": "https://registry.npmjs.org/@material/chips/-/chips-10.0.0.tgz",
       "integrity": "sha512-K3FQaN/Y7nlgVtTyZjWOD88Q+5VkNJBUwx0Jv9gONuRjDnelGNbTnzVe1/ESAFVK7fRSoQsEdSM8DVKsjrjyVw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -1582,7 +1575,6 @@
       "resolved": "https://registry.npmjs.org/@material/circular-progress/-/circular-progress-10.0.0.tgz",
       "integrity": "sha512-lb76jzi10OmsVN2XhLhEZpWBilx0TMCZESQ7fIub4FQuSwBucz7Wn/+d5goRkotrOKWzh2HvJ/vnpku5up/a1A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -1597,7 +1589,6 @@
       "resolved": "https://registry.npmjs.org/@material/data-table/-/data-table-10.0.0.tgz",
       "integrity": "sha512-6zmqZk1EkmyjTW4SK/HC2SJX2LsNEKYAjrlEU9XZKEJCA381Z3+YJNrePNHbK9JEZYtGH4yq7Yu8kH5FlBJa9A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -1623,15 +1614,13 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@material/density/-/density-10.0.0.tgz",
       "integrity": "sha512-nLf8N5e6tEYo+W762z3coTDl2b1FFKJv/uU+E5UsBYOL0ftXrOMtiYSwg9MJjfWtdG+uUBfb3VLcBvIl2x3C0w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@material/dialog": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@material/dialog/-/dialog-10.0.0.tgz",
       "integrity": "sha512-vAupxjKxP9iMCmFCkE0PuLCrePdBqdOvJBTv++JP1v+t/Vu+5FLu6rHYIWKwTivqrIgSrLS2L0Lyc1VlJzQqLg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -1654,7 +1643,6 @@
       "resolved": "https://registry.npmjs.org/@material/dom/-/dom-10.0.0.tgz",
       "integrity": "sha512-rimaFIRsbacSjnk/1IqQZLOjoIWYhmuR6AZR35nkeAYg0H3DmLuNTGyAgsMaC8O/1vBcAp+c4N9WASkITCOE5A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/feature-targeting": "^10.0.0",
         "tslib": "^1.9.3"
@@ -1665,7 +1653,6 @@
       "resolved": "https://registry.npmjs.org/@material/drawer/-/drawer-10.0.0.tgz",
       "integrity": "sha512-x2B8Cqz8x3ecXU4gkFCZBzWNKC5q+oDc73dce/rPNoR87ndzLhMcu6P7mD/tBaNBJHypfQk1SBkbFrMYHAfncg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -1686,7 +1673,6 @@
       "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-10.0.0.tgz",
       "integrity": "sha512-D/CeTIkRmV9iLJDzUnKSt2FTM7SLv3ixQjindNaAEAaCdsaoUfx6Q2dRAlqQOL0y6yeTvvpxK9IFwu411J3xXw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -1699,7 +1685,6 @@
       "resolved": "https://registry.npmjs.org/@material/fab/-/fab-10.0.0.tgz",
       "integrity": "sha512-TR+xGD0fjwyP9/E0XkXkmHBhzgsgYLEOp/uMf0GRoSXlDypU9E83oh3ZH8w4u2MrHfSM65xB3tMHchSNzXkb2Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/dom": "^10.0.0",
@@ -1717,15 +1702,13 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-10.0.0.tgz",
       "integrity": "sha512-Pn48jeeD2ScMq0NoR0k9SeC3UFOOTarKNIYxL+TkFRLGks/TgFoSIDRwXCzva/9umw9/Q2xOWrY/Gqs1zBIgOA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@material/floating-label": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@material/floating-label/-/floating-label-10.0.0.tgz",
       "integrity": "sha512-np5ETpkZiv4WkgO9b4PKM9oWnuMaF7smxPx0ef4xvwj1jfj7z40OSV85p+3xVp9fJ6UkiDQBqqB+5xquf/o++w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -1742,7 +1725,6 @@
       "resolved": "https://registry.npmjs.org/@material/form-field/-/form-field-10.0.0.tgz",
       "integrity": "sha512-OP4SiWVClIfNZYOUzuJpkY67ZRXTm2N4KF1xtfE7aN5mBjJfzrJkhjZ7wrfeWIDx4noGtGDn4wb8ui3kBk87KQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/base": "^10.0.0",
         "@material/feature-targeting": "^10.0.0",
@@ -1758,7 +1740,6 @@
       "resolved": "https://registry.npmjs.org/@material/icon-button/-/icon-button-10.0.0.tgz",
       "integrity": "sha512-e7oQq2LlUA+UGGzlgvityPV+bTRJ7sFs8grlwM0C86adXzc/6nYBNmmgcqUpQDiCtBj5Dqo8oQSUVGRkHIqEiQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/base": "^10.0.0",
         "@material/density": "^10.0.0",
@@ -1774,7 +1755,6 @@
       "resolved": "https://registry.npmjs.org/@material/image-list/-/image-list-10.0.0.tgz",
       "integrity": "sha512-7DZkZNCTsxDsiISAEv7DkxP99On4cG+kMUMjf475K2hjJ1JtilOg27PoV2RTWp7umIk34TifD4ydEqDvQ3q8pQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/feature-targeting": "^10.0.0",
         "@material/shape": "^10.0.0",
@@ -1786,15 +1766,13 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@material/layout-grid/-/layout-grid-10.0.0.tgz",
       "integrity": "sha512-r6MydDwpGwawgEBjENrp7699r+ioGpUd/ntAfrYxeVqRT43Qkoa6/VHLYHDubv+RlaG130PQ5ipNPkCgqHURMw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@material/line-ripple": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@material/line-ripple/-/line-ripple-10.0.0.tgz",
       "integrity": "sha512-68Kn1cs2T0GWRdAfdtoDz5grROVeGtS9WSYe0kCDsoXFmHEjGhxVZfIT3E6as6NcrP7haLPJEV6ACg4tvzr8uQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -1808,7 +1786,6 @@
       "resolved": "https://registry.npmjs.org/@material/linear-progress/-/linear-progress-10.0.0.tgz",
       "integrity": "sha512-RjfVNRCbhEeyIw5MSb9PNH7Xuhn6af90ksfjmABjYHkTFVhSDdJMrDCOD6gdH8UE5vGDIulS+ZMgIy4pQOmnxA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -1824,7 +1801,6 @@
       "resolved": "https://registry.npmjs.org/@material/list/-/list-10.0.0.tgz",
       "integrity": "sha512-LYNntZbyu4ByJphtg3sGxYiwGdt+Lr2jZZLaOk4Xr8v98xDEW96yjB7CjSGh7HI//snJ9PN0QmEfTJ9kavswLw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/base": "^10.0.0",
         "@material/density": "^10.0.0",
@@ -1843,7 +1819,6 @@
       "resolved": "https://registry.npmjs.org/@material/menu/-/menu-10.0.0.tgz",
       "integrity": "sha512-UvutTmhENZc7j1XO14bL/jj0CFQV//8FiQT8hqnZ2/bisX4dyVkwJcs/iSj7ZumQ9KSqn62XMP+DiOothz55Ew==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/base": "^10.0.0",
         "@material/dom": "^10.0.0",
@@ -1862,7 +1837,6 @@
       "resolved": "https://registry.npmjs.org/@material/menu-surface/-/menu-surface-10.0.0.tgz",
       "integrity": "sha512-YH/FYlUSmKZoEDtPA+EpV+WQy9caLsa3O+K9MnVq5hpUcg/ezKUa8hP59de+3ubP5Vex60OyVtRs9A/btb64PA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -1879,7 +1853,6 @@
       "resolved": "https://registry.npmjs.org/@material/notched-outline/-/notched-outline-10.0.0.tgz",
       "integrity": "sha512-SgiLTX2Wy15EAVl6eve+5ruBpnmkN3BclB/6RARvswld6uXhJ4HFSM01sztg4QPhCDehyqNIZvo/LdtyK+99vg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/base": "^10.0.0",
         "@material/feature-targeting": "^10.0.0",
@@ -1895,7 +1868,6 @@
       "resolved": "https://registry.npmjs.org/@material/progress-indicator/-/progress-indicator-10.0.0.tgz",
       "integrity": "sha512-s0IXhhyBBlfXoaN7WKKpsiw4qtG29JXTVhj0/IR2QdDx82QOTxYlQkclqBBlkr+H40LKmEYN7dUWJVWJf8QlMw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^1.9.3"
       }
@@ -1905,7 +1877,6 @@
       "resolved": "https://registry.npmjs.org/@material/radio/-/radio-10.0.0.tgz",
       "integrity": "sha512-Lvjfz0NjmwvZ4vvi2aCNQdrvdbFuTsVDjrWCHJgeR7kBLOYM7g8li7G6EpD6GgcMvSCysQ4IljCXUVIimnFoCg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -1923,7 +1894,6 @@
       "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-10.0.0.tgz",
       "integrity": "sha512-KZPJ6YvLFJKkulUemKFq/Y3h9/Pbta+zOjBN1ZoeiP5++5thfsMJuL+L2bWa4GqUjSj66xW75LQrxX/ammCYzw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -1938,7 +1908,6 @@
       "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-10.0.0.tgz",
       "integrity": "sha512-887Dq0JrlRx5uwQ2Ku4Gig0e7iMIdKAAvvk/Wnglo9jFUvJE94rgSyyDLbwsN4vo1s33PwxHK1uWteALkzMQWw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/theme": "^10.0.0"
       }
@@ -1948,7 +1917,6 @@
       "resolved": "https://registry.npmjs.org/@material/segmented-button/-/segmented-button-10.0.0.tgz",
       "integrity": "sha512-98+1Wny1yPJWNkhqPgvKPQtOlxlIXMvB0XHegO51G3JnDWDcyay+JzumDJAlwX3yuhekQ61oQDfEPUb7bZOR3g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/base": "^10.0.0",
         "@material/elevation": "^10.0.0",
@@ -1964,7 +1932,6 @@
       "resolved": "https://registry.npmjs.org/@material/select/-/select-10.0.0.tgz",
       "integrity": "sha512-1K39WyPpD7cMS1GBNYvQ+o6uBldy3rilqwiBV9zQHIIcAIk9SN7e++siKxbSYGq2/aeMX0sdQDkbGZhEGXupGQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -1990,7 +1957,6 @@
       "resolved": "https://registry.npmjs.org/@material/shape/-/shape-10.0.0.tgz",
       "integrity": "sha512-2zUib2htoZz21ULa9lNd4llGOWlZcGLBKKJdNV6wsyPlqdh6SjEXf3Fz1BrWV6pQVW3fhnhn+oTFLMveV1mMZw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/feature-targeting": "^10.0.0",
         "@material/rtl": "^10.0.0",
@@ -2002,7 +1968,6 @@
       "resolved": "https://registry.npmjs.org/@material/slider/-/slider-10.0.0.tgz",
       "integrity": "sha512-RsCPCk/dWba0W1LxRCALM9iVQtww2wgEZM7P/erQQyNKHDCR9CPNrCW5Y9HUhtzr+j3RaFqkSGDzJ1+WpIOQ5g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -2021,7 +1986,6 @@
       "resolved": "https://registry.npmjs.org/@material/snackbar/-/snackbar-10.0.0.tgz",
       "integrity": "sha512-Cp/OpLZm6ze+/jxpyf2D1jUNvdyhn3MhYcH1EWUyJowJk0wc0DOvWWgrZcVmyqTCROJUmTlL+l35EQ3f7rkjxQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -2043,7 +2007,6 @@
       "resolved": "https://registry.npmjs.org/@material/switch/-/switch-10.0.0.tgz",
       "integrity": "sha512-2UZgof9g52fJOsGgftnmb66WC/yyESZssvbxhLkUVIwGTephz7KXfRWPvoBWBEC2Gwk5FW2Btq3nw5uRKPNj1A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -2062,7 +2025,6 @@
       "resolved": "https://registry.npmjs.org/@material/tab/-/tab-10.0.0.tgz",
       "integrity": "sha512-+NdLlk3japU7I7Ar6ZrihQKxZdk8mIkRv8fXoRZ0KjvHyi6y5tYT++tMHDCzvdzWm24z9Du3aiup1QIsKaI24Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/base": "^10.0.0",
         "@material/feature-targeting": "^10.0.0",
@@ -2079,7 +2041,6 @@
       "resolved": "https://registry.npmjs.org/@material/tab-bar/-/tab-bar-10.0.0.tgz",
       "integrity": "sha512-C0+Cc4L2AbKKkmrv+DF4d3UPfjIDSQs7Iue/X4q4Y+JmOPb6FgUQOYAJOx7V4/5YPUTECAa/lUVYoFMqDxdRRw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -2095,7 +2056,6 @@
       "resolved": "https://registry.npmjs.org/@material/tab-indicator/-/tab-indicator-10.0.0.tgz",
       "integrity": "sha512-CpSyR76q51UZ1nhW5quVvYpPGA//Zy2Mjhdp4y+T8yVUtR2MBGj6LjeQz3T4cuGq4GL+yEIw6KPOBFdtCNRqaQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -2109,7 +2069,6 @@
       "resolved": "https://registry.npmjs.org/@material/tab-scroller/-/tab-scroller-10.0.0.tgz",
       "integrity": "sha512-OT0BNGg5Lai8slprm9GfGKm0npZCh9+NYoYic7nNII3icpqCbgnayyZpHA215tQ8gi6wx+UEm+bWMlz4TEGlQg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -2124,7 +2083,6 @@
       "resolved": "https://registry.npmjs.org/@material/textfield/-/textfield-10.0.0.tgz",
       "integrity": "sha512-EqqG1c8J8pGTBV3ogXlEi3ZxGuG8qAGYw9Z3QI+r3FvYvrX4qp9Xl1ifDRweVF18eJ28DINXqBdL7XNmnCaZpw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -2147,7 +2105,6 @@
       "resolved": "https://registry.npmjs.org/@material/theme/-/theme-10.0.0.tgz",
       "integrity": "sha512-ll5UFjPR6np4jgTzDQO85VQg6FgLM0Vy1MlyJVRr/kn+2adX5hDxiBOnuC9fTeVhIBBPjbAMOFPa6VhNmAmkvg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/feature-targeting": "^10.0.0"
       }
@@ -2157,7 +2114,6 @@
       "resolved": "https://registry.npmjs.org/@material/tooltip/-/tooltip-10.0.0.tgz",
       "integrity": "sha512-sH0c9ERNGZe+QaxRNQIFczKNu2y4IbDsuhb5MalY0XZ6jurpdm/1UxEBvrhquXkUUebJ0tPzbOJ214+LJVSh5A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -2176,7 +2132,6 @@
       "resolved": "https://registry.npmjs.org/@material/top-app-bar/-/top-app-bar-10.0.0.tgz",
       "integrity": "sha512-9UKxshyQw/FYX+V5qpsNcyU+4Z+3bvxa415jZkorq+ffoaIzKjc30zBGYcpQSAs2wwobiSp5srMmrTuU/x9k7A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -2194,7 +2149,6 @@
       "resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-10.0.0.tgz",
       "integrity": "sha512-uDWxktK/CODyNNyvXwzTFXcxqujQrVX3LoIsOXu87Z0fq4n2u74WlemJoniMbVKdsKsiJWcZ1uvrvhSeOdNQ2Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/base": "^10.0.0",
         "@material/feature-targeting": "^10.0.0"
@@ -2205,7 +2159,6 @@
       "resolved": "https://registry.npmjs.org/@material/typography/-/typography-10.0.0.tgz",
       "integrity": "sha512-RtFfL/mfOOkliL/iXY1YPrx8Rw1LZWQC4Jpn2zs04xM+AhhDOcD4Hek5xcvWFjhzEmPUz7yhCTWsMOmVtsXzig==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/feature-targeting": "^10.0.0",
         "@material/theme": "^10.0.0"
@@ -5071,7 +5024,6 @@
       "resolved": "https://registry.npmjs.org/material-components-web/-/material-components-web-10.0.0.tgz",
       "integrity": "sha512-8zRnmPyZmpD3zKImMCbMrvGx7IwOutGPTrrNNLNEcrmEXCoBVGoorc+6gyvs2bugScgZmLf/nLAXlYlHel7PYQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@material/animation": "^10.0.0",
         "@material/auto-init": "^10.0.0",
@@ -8807,8 +8759,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.3.2",
@@ -10603,7 +10554,6 @@
       "resolved": "https://registry.npmjs.org/@material/animation/-/animation-10.0.0.tgz",
       "integrity": "sha512-5e8e+W+n105rfSTRI5Mfmh9VMqzNG8+OhxjfDr7k0lYCfjbkT8LsAInonC5EotJzcaxD0vtDUqRqdW8xKIXNWg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -10613,7 +10563,6 @@
       "resolved": "https://registry.npmjs.org/@material/auto-init/-/auto-init-10.0.0.tgz",
       "integrity": "sha512-Deawx+0P7D7A6kCeYcG40sM+pi3O1qAp838fu16Rupy6ZdZ4z3fXQbcHXq4ZQNysRxIdC6S7DjJ/VI340HI+mA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/base": "^10.0.0",
         "tslib": "^1.9.3"
@@ -10624,7 +10573,6 @@
       "resolved": "https://registry.npmjs.org/@material/banner/-/banner-10.0.0.tgz",
       "integrity": "sha512-USIk8WIFHLGafjxTsMjNJf8AsRdAvI+XZjEKkPwvpqgFcBLgDa7rRVO8YsgnXUdcqq3hitAo+w1NbNMU2pogDg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/base": "^10.0.0",
         "@material/button": "^10.0.0",
@@ -10643,7 +10591,6 @@
       "resolved": "https://registry.npmjs.org/@material/base/-/base-10.0.0.tgz",
       "integrity": "sha512-PQWNSsNYVvMcWKsRFHgs5JjsHuv6cTogdlp9uhx5ChdLNCkflpXlMKJ7aYfcl56fdLntWQbxXowLh1JAfrTrmg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -10653,7 +10600,6 @@
       "resolved": "https://registry.npmjs.org/@material/button/-/button-10.0.0.tgz",
       "integrity": "sha512-OHIJtlyM+U+MqvPm0N0y9kHf+SFS0I7zE520MulQJywgZhHmU+mz2kwgy+tVxOTceVglQzRZP3KkrwUkf4U0bg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/density": "^10.0.0",
         "@material/dom": "^10.0.0",
@@ -10672,7 +10618,6 @@
       "resolved": "https://registry.npmjs.org/@material/card/-/card-10.0.0.tgz",
       "integrity": "sha512-IwdmUdrMDKb27K6xUhRSafPNbrAmcrPSxM3E8ad1Hk55+9O8Tl9SnGfOQGNtocGa8O7qFr8jsiqdIrxJN85VEA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/dom": "^10.0.0",
         "@material/elevation": "^10.0.0",
@@ -10688,7 +10633,6 @@
       "resolved": "https://registry.npmjs.org/@material/checkbox/-/checkbox-10.0.0.tgz",
       "integrity": "sha512-aZc8KLo+yT15tnEpJWBvqJhUFEVqAKs56DGC8PaKfwfJJMVS0D4Hek61cpl4Jthv6j5eduvpiZ/2DRE8D530Hg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -10706,7 +10650,6 @@
       "resolved": "https://registry.npmjs.org/@material/chips/-/chips-10.0.0.tgz",
       "integrity": "sha512-K3FQaN/Y7nlgVtTyZjWOD88Q+5VkNJBUwx0Jv9gONuRjDnelGNbTnzVe1/ESAFVK7fRSoQsEdSM8DVKsjrjyVw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -10729,7 +10672,6 @@
       "resolved": "https://registry.npmjs.org/@material/circular-progress/-/circular-progress-10.0.0.tgz",
       "integrity": "sha512-lb76jzi10OmsVN2XhLhEZpWBilx0TMCZESQ7fIub4FQuSwBucz7Wn/+d5goRkotrOKWzh2HvJ/vnpku5up/a1A==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -10744,7 +10686,6 @@
       "resolved": "https://registry.npmjs.org/@material/data-table/-/data-table-10.0.0.tgz",
       "integrity": "sha512-6zmqZk1EkmyjTW4SK/HC2SJX2LsNEKYAjrlEU9XZKEJCA381Z3+YJNrePNHbK9JEZYtGH4yq7Yu8kH5FlBJa9A==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -10770,15 +10711,13 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@material/density/-/density-10.0.0.tgz",
       "integrity": "sha512-nLf8N5e6tEYo+W762z3coTDl2b1FFKJv/uU+E5UsBYOL0ftXrOMtiYSwg9MJjfWtdG+uUBfb3VLcBvIl2x3C0w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@material/dialog": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@material/dialog/-/dialog-10.0.0.tgz",
       "integrity": "sha512-vAupxjKxP9iMCmFCkE0PuLCrePdBqdOvJBTv++JP1v+t/Vu+5FLu6rHYIWKwTivqrIgSrLS2L0Lyc1VlJzQqLg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -10801,7 +10740,6 @@
       "resolved": "https://registry.npmjs.org/@material/dom/-/dom-10.0.0.tgz",
       "integrity": "sha512-rimaFIRsbacSjnk/1IqQZLOjoIWYhmuR6AZR35nkeAYg0H3DmLuNTGyAgsMaC8O/1vBcAp+c4N9WASkITCOE5A==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/feature-targeting": "^10.0.0",
         "tslib": "^1.9.3"
@@ -10812,7 +10750,6 @@
       "resolved": "https://registry.npmjs.org/@material/drawer/-/drawer-10.0.0.tgz",
       "integrity": "sha512-x2B8Cqz8x3ecXU4gkFCZBzWNKC5q+oDc73dce/rPNoR87ndzLhMcu6P7mD/tBaNBJHypfQk1SBkbFrMYHAfncg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -10833,7 +10770,6 @@
       "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-10.0.0.tgz",
       "integrity": "sha512-D/CeTIkRmV9iLJDzUnKSt2FTM7SLv3ixQjindNaAEAaCdsaoUfx6Q2dRAlqQOL0y6yeTvvpxK9IFwu411J3xXw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -10846,7 +10782,6 @@
       "resolved": "https://registry.npmjs.org/@material/fab/-/fab-10.0.0.tgz",
       "integrity": "sha512-TR+xGD0fjwyP9/E0XkXkmHBhzgsgYLEOp/uMf0GRoSXlDypU9E83oh3ZH8w4u2MrHfSM65xB3tMHchSNzXkb2Q==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/dom": "^10.0.0",
@@ -10864,15 +10799,13 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-10.0.0.tgz",
       "integrity": "sha512-Pn48jeeD2ScMq0NoR0k9SeC3UFOOTarKNIYxL+TkFRLGks/TgFoSIDRwXCzva/9umw9/Q2xOWrY/Gqs1zBIgOA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@material/floating-label": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@material/floating-label/-/floating-label-10.0.0.tgz",
       "integrity": "sha512-np5ETpkZiv4WkgO9b4PKM9oWnuMaF7smxPx0ef4xvwj1jfj7z40OSV85p+3xVp9fJ6UkiDQBqqB+5xquf/o++w==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -10889,7 +10822,6 @@
       "resolved": "https://registry.npmjs.org/@material/form-field/-/form-field-10.0.0.tgz",
       "integrity": "sha512-OP4SiWVClIfNZYOUzuJpkY67ZRXTm2N4KF1xtfE7aN5mBjJfzrJkhjZ7wrfeWIDx4noGtGDn4wb8ui3kBk87KQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/base": "^10.0.0",
         "@material/feature-targeting": "^10.0.0",
@@ -10905,7 +10837,6 @@
       "resolved": "https://registry.npmjs.org/@material/icon-button/-/icon-button-10.0.0.tgz",
       "integrity": "sha512-e7oQq2LlUA+UGGzlgvityPV+bTRJ7sFs8grlwM0C86adXzc/6nYBNmmgcqUpQDiCtBj5Dqo8oQSUVGRkHIqEiQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/base": "^10.0.0",
         "@material/density": "^10.0.0",
@@ -10921,7 +10852,6 @@
       "resolved": "https://registry.npmjs.org/@material/image-list/-/image-list-10.0.0.tgz",
       "integrity": "sha512-7DZkZNCTsxDsiISAEv7DkxP99On4cG+kMUMjf475K2hjJ1JtilOg27PoV2RTWp7umIk34TifD4ydEqDvQ3q8pQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/feature-targeting": "^10.0.0",
         "@material/shape": "^10.0.0",
@@ -10933,15 +10863,13 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@material/layout-grid/-/layout-grid-10.0.0.tgz",
       "integrity": "sha512-r6MydDwpGwawgEBjENrp7699r+ioGpUd/ntAfrYxeVqRT43Qkoa6/VHLYHDubv+RlaG130PQ5ipNPkCgqHURMw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@material/line-ripple": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@material/line-ripple/-/line-ripple-10.0.0.tgz",
       "integrity": "sha512-68Kn1cs2T0GWRdAfdtoDz5grROVeGtS9WSYe0kCDsoXFmHEjGhxVZfIT3E6as6NcrP7haLPJEV6ACg4tvzr8uQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -10955,7 +10883,6 @@
       "resolved": "https://registry.npmjs.org/@material/linear-progress/-/linear-progress-10.0.0.tgz",
       "integrity": "sha512-RjfVNRCbhEeyIw5MSb9PNH7Xuhn6af90ksfjmABjYHkTFVhSDdJMrDCOD6gdH8UE5vGDIulS+ZMgIy4pQOmnxA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -10971,7 +10898,6 @@
       "resolved": "https://registry.npmjs.org/@material/list/-/list-10.0.0.tgz",
       "integrity": "sha512-LYNntZbyu4ByJphtg3sGxYiwGdt+Lr2jZZLaOk4Xr8v98xDEW96yjB7CjSGh7HI//snJ9PN0QmEfTJ9kavswLw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/base": "^10.0.0",
         "@material/density": "^10.0.0",
@@ -10990,7 +10916,6 @@
       "resolved": "https://registry.npmjs.org/@material/menu/-/menu-10.0.0.tgz",
       "integrity": "sha512-UvutTmhENZc7j1XO14bL/jj0CFQV//8FiQT8hqnZ2/bisX4dyVkwJcs/iSj7ZumQ9KSqn62XMP+DiOothz55Ew==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/base": "^10.0.0",
         "@material/dom": "^10.0.0",
@@ -11009,7 +10934,6 @@
       "resolved": "https://registry.npmjs.org/@material/menu-surface/-/menu-surface-10.0.0.tgz",
       "integrity": "sha512-YH/FYlUSmKZoEDtPA+EpV+WQy9caLsa3O+K9MnVq5hpUcg/ezKUa8hP59de+3ubP5Vex60OyVtRs9A/btb64PA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -11026,7 +10950,6 @@
       "resolved": "https://registry.npmjs.org/@material/notched-outline/-/notched-outline-10.0.0.tgz",
       "integrity": "sha512-SgiLTX2Wy15EAVl6eve+5ruBpnmkN3BclB/6RARvswld6uXhJ4HFSM01sztg4QPhCDehyqNIZvo/LdtyK+99vg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/base": "^10.0.0",
         "@material/feature-targeting": "^10.0.0",
@@ -11042,7 +10965,6 @@
       "resolved": "https://registry.npmjs.org/@material/progress-indicator/-/progress-indicator-10.0.0.tgz",
       "integrity": "sha512-s0IXhhyBBlfXoaN7WKKpsiw4qtG29JXTVhj0/IR2QdDx82QOTxYlQkclqBBlkr+H40LKmEYN7dUWJVWJf8QlMw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -11052,7 +10974,6 @@
       "resolved": "https://registry.npmjs.org/@material/radio/-/radio-10.0.0.tgz",
       "integrity": "sha512-Lvjfz0NjmwvZ4vvi2aCNQdrvdbFuTsVDjrWCHJgeR7kBLOYM7g8li7G6EpD6GgcMvSCysQ4IljCXUVIimnFoCg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -11070,7 +10991,6 @@
       "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-10.0.0.tgz",
       "integrity": "sha512-KZPJ6YvLFJKkulUemKFq/Y3h9/Pbta+zOjBN1ZoeiP5++5thfsMJuL+L2bWa4GqUjSj66xW75LQrxX/ammCYzw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -11085,7 +11005,6 @@
       "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-10.0.0.tgz",
       "integrity": "sha512-887Dq0JrlRx5uwQ2Ku4Gig0e7iMIdKAAvvk/Wnglo9jFUvJE94rgSyyDLbwsN4vo1s33PwxHK1uWteALkzMQWw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/theme": "^10.0.0"
       }
@@ -11095,7 +11014,6 @@
       "resolved": "https://registry.npmjs.org/@material/segmented-button/-/segmented-button-10.0.0.tgz",
       "integrity": "sha512-98+1Wny1yPJWNkhqPgvKPQtOlxlIXMvB0XHegO51G3JnDWDcyay+JzumDJAlwX3yuhekQ61oQDfEPUb7bZOR3g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/base": "^10.0.0",
         "@material/elevation": "^10.0.0",
@@ -11111,7 +11029,6 @@
       "resolved": "https://registry.npmjs.org/@material/select/-/select-10.0.0.tgz",
       "integrity": "sha512-1K39WyPpD7cMS1GBNYvQ+o6uBldy3rilqwiBV9zQHIIcAIk9SN7e++siKxbSYGq2/aeMX0sdQDkbGZhEGXupGQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -11137,7 +11054,6 @@
       "resolved": "https://registry.npmjs.org/@material/shape/-/shape-10.0.0.tgz",
       "integrity": "sha512-2zUib2htoZz21ULa9lNd4llGOWlZcGLBKKJdNV6wsyPlqdh6SjEXf3Fz1BrWV6pQVW3fhnhn+oTFLMveV1mMZw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/feature-targeting": "^10.0.0",
         "@material/rtl": "^10.0.0",
@@ -11149,7 +11065,6 @@
       "resolved": "https://registry.npmjs.org/@material/slider/-/slider-10.0.0.tgz",
       "integrity": "sha512-RsCPCk/dWba0W1LxRCALM9iVQtww2wgEZM7P/erQQyNKHDCR9CPNrCW5Y9HUhtzr+j3RaFqkSGDzJ1+WpIOQ5g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -11168,7 +11083,6 @@
       "resolved": "https://registry.npmjs.org/@material/snackbar/-/snackbar-10.0.0.tgz",
       "integrity": "sha512-Cp/OpLZm6ze+/jxpyf2D1jUNvdyhn3MhYcH1EWUyJowJk0wc0DOvWWgrZcVmyqTCROJUmTlL+l35EQ3f7rkjxQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -11190,7 +11104,6 @@
       "resolved": "https://registry.npmjs.org/@material/switch/-/switch-10.0.0.tgz",
       "integrity": "sha512-2UZgof9g52fJOsGgftnmb66WC/yyESZssvbxhLkUVIwGTephz7KXfRWPvoBWBEC2Gwk5FW2Btq3nw5uRKPNj1A==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -11209,7 +11122,6 @@
       "resolved": "https://registry.npmjs.org/@material/tab/-/tab-10.0.0.tgz",
       "integrity": "sha512-+NdLlk3japU7I7Ar6ZrihQKxZdk8mIkRv8fXoRZ0KjvHyi6y5tYT++tMHDCzvdzWm24z9Du3aiup1QIsKaI24Q==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/base": "^10.0.0",
         "@material/feature-targeting": "^10.0.0",
@@ -11226,7 +11138,6 @@
       "resolved": "https://registry.npmjs.org/@material/tab-bar/-/tab-bar-10.0.0.tgz",
       "integrity": "sha512-C0+Cc4L2AbKKkmrv+DF4d3UPfjIDSQs7Iue/X4q4Y+JmOPb6FgUQOYAJOx7V4/5YPUTECAa/lUVYoFMqDxdRRw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -11242,7 +11153,6 @@
       "resolved": "https://registry.npmjs.org/@material/tab-indicator/-/tab-indicator-10.0.0.tgz",
       "integrity": "sha512-CpSyR76q51UZ1nhW5quVvYpPGA//Zy2Mjhdp4y+T8yVUtR2MBGj6LjeQz3T4cuGq4GL+yEIw6KPOBFdtCNRqaQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -11256,7 +11166,6 @@
       "resolved": "https://registry.npmjs.org/@material/tab-scroller/-/tab-scroller-10.0.0.tgz",
       "integrity": "sha512-OT0BNGg5Lai8slprm9GfGKm0npZCh9+NYoYic7nNII3icpqCbgnayyZpHA215tQ8gi6wx+UEm+bWMlz4TEGlQg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -11271,7 +11180,6 @@
       "resolved": "https://registry.npmjs.org/@material/textfield/-/textfield-10.0.0.tgz",
       "integrity": "sha512-EqqG1c8J8pGTBV3ogXlEi3ZxGuG8qAGYw9Z3QI+r3FvYvrX4qp9Xl1ifDRweVF18eJ28DINXqBdL7XNmnCaZpw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -11294,7 +11202,6 @@
       "resolved": "https://registry.npmjs.org/@material/theme/-/theme-10.0.0.tgz",
       "integrity": "sha512-ll5UFjPR6np4jgTzDQO85VQg6FgLM0Vy1MlyJVRr/kn+2adX5hDxiBOnuC9fTeVhIBBPjbAMOFPa6VhNmAmkvg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/feature-targeting": "^10.0.0"
       }
@@ -11304,7 +11211,6 @@
       "resolved": "https://registry.npmjs.org/@material/tooltip/-/tooltip-10.0.0.tgz",
       "integrity": "sha512-sH0c9ERNGZe+QaxRNQIFczKNu2y4IbDsuhb5MalY0XZ6jurpdm/1UxEBvrhquXkUUebJ0tPzbOJ214+LJVSh5A==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -11323,7 +11229,6 @@
       "resolved": "https://registry.npmjs.org/@material/top-app-bar/-/top-app-bar-10.0.0.tgz",
       "integrity": "sha512-9UKxshyQw/FYX+V5qpsNcyU+4Z+3bvxa415jZkorq+ffoaIzKjc30zBGYcpQSAs2wwobiSp5srMmrTuU/x9k7A==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/base": "^10.0.0",
@@ -11341,7 +11246,6 @@
       "resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-10.0.0.tgz",
       "integrity": "sha512-uDWxktK/CODyNNyvXwzTFXcxqujQrVX3LoIsOXu87Z0fq4n2u74WlemJoniMbVKdsKsiJWcZ1uvrvhSeOdNQ2Q==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/base": "^10.0.0",
         "@material/feature-targeting": "^10.0.0"
@@ -11352,7 +11256,6 @@
       "resolved": "https://registry.npmjs.org/@material/typography/-/typography-10.0.0.tgz",
       "integrity": "sha512-RtFfL/mfOOkliL/iXY1YPrx8Rw1LZWQC4Jpn2zs04xM+AhhDOcD4Hek5xcvWFjhzEmPUz7yhCTWsMOmVtsXzig==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/feature-targeting": "^10.0.0",
         "@material/theme": "^10.0.0"
@@ -13612,7 +13515,6 @@
       "resolved": "https://registry.npmjs.org/material-components-web/-/material-components-web-10.0.0.tgz",
       "integrity": "sha512-8zRnmPyZmpD3zKImMCbMrvGx7IwOutGPTrrNNLNEcrmEXCoBVGoorc+6gyvs2bugScgZmLf/nLAXlYlHel7PYQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@material/animation": "^10.0.0",
         "@material/auto-init": "^10.0.0",
@@ -16446,8 +16348,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@rollup/plugin-node-resolve": "^11.2.0",
         "@roxi/routify": "^2.15.1",
         "@silintl/svelte-google-places-autocomplete": "^1.1.1",
-        "@silintl/ui-components": "^2.1.0",
+        "@silintl/ui-components": "^2.2.0",
         "bootstrap": "^4.4.1",
         "date-fns": "^2.12.0",
         "fa-svelte": "^3.1.0",
@@ -2477,11 +2477,10 @@
       "dev": true
     },
     "node_modules/@silintl/ui-components": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@silintl/ui-components/-/ui-components-2.1.0.tgz",
-      "integrity": "sha512-VVZBN12ip3nLfLmwIxj9aLyuTdnVrVF7XTBS6tDOgIry390WTu4etsM1vQLACug71gSJYrDQMfLsaOLsYPecmA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@silintl/ui-components/-/ui-components-2.2.0.tgz",
+      "integrity": "sha512-DlXESGLYwdozIddiIff5UbmJJiRZjNWvXjWH308YqqX5pXPImEjZZU/EE4YWw2WMBX/ds+FP4EiHVunpw3dtXA==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "@roxi/routify": "^2.x",
         "material-components-web": "^10.0.0",
@@ -11572,9 +11571,9 @@
       "dev": true
     },
     "@silintl/ui-components": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@silintl/ui-components/-/ui-components-2.1.0.tgz",
-      "integrity": "sha512-VVZBN12ip3nLfLmwIxj9aLyuTdnVrVF7XTBS6tDOgIry390WTu4etsM1vQLACug71gSJYrDQMfLsaOLsYPecmA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@silintl/ui-components/-/ui-components-2.2.0.tgz",
+      "integrity": "sha512-DlXESGLYwdozIddiIff5UbmJJiRZjNWvXjWH308YqqX5pXPImEjZZU/EE4YWw2WMBX/ds+FP4EiHVunpw3dtXA==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "date-fns": "^2.12.0",
     "fa-svelte": "^3.1.0",
     "jquery": "^3.5.1",
+    "material-components-web": "^10.0.0",
     "npm-run-all": "^4.1.5",
     "popper.js": "^1.16.1",
     "postcss": "^8.2.13",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@roxi/routify": "^2.15.1",
     "@silintl/svelte-google-places-autocomplete": "^1.1.1",
-    "@silintl/ui-components": "^2.1.0",
+    "@silintl/ui-components": "^2.2.0",
     "bootstrap": "^4.4.1",
     "date-fns": "^2.12.0",
     "fa-svelte": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@roxi/routify": "^2.15.1",
     "@silintl/svelte-google-places-autocomplete": "^1.1.1",
-    "@silintl/ui-components": "^2.2.0",
+    "@silintl/ui-components": "^2.2.1",
     "bootstrap": "^4.4.1",
     "date-fns": "^2.12.0",
     "fa-svelte": "^3.1.0",

--- a/src/components/RequestCard.svelte
+++ b/src/components/RequestCard.svelte
@@ -19,6 +19,10 @@
     overflow-wrap: anywhere;
   }
 
+  .header {
+    padding-left: 6px;
+  }
+
   .multi-line-truncate {
     /* See https://stackoverflow.com/a/13924997 and https://caniuse.com/#search=line-clamp for details. */
     overflow: hidden;
@@ -59,13 +63,13 @@
 </style>
 
 <Card isClickable noPadding on:click={gotoRequest} on:keypress={gotoRequest} class="h-100 py-1">
-  <div class="flex justify-between align-items-center black m-2 px-2">
+  <div class="flex justify-between align-items-center black m-2 px-1">
     <UserAvatar {user} small />
 
-    <div class="px-2">
+    <div class="header">
       <h5 class="multi-line-truncate my-0" class:smaller>{request.title}</h5>
 
-      <div class="multi-line-truncate" class:smaller>{user.nickname}</div>
+      <div class="multi-line-truncate fs-14" class:smaller>{user.nickname}</div>
     </div>
 
     <span class="material-icons">chat</span>

--- a/src/components/RequestCard.svelte
+++ b/src/components/RequestCard.svelte
@@ -54,8 +54,8 @@
   }
 </style>
 
-<Card isClickable on:click={gotoRequest} on:keypress={gotoRequest} class="h-100 py-1">
-  <div class="flex justify-between align-items-center black m-2">
+<Card isClickable noPadding on:click={gotoRequest} on:keypress={gotoRequest} class="h-100 py-1">
+  <div class="flex justify-between align-items-center black m-2 px-2">
     <UserAvatar {user} small />
 
     <div>
@@ -71,7 +71,7 @@
     <RequestImage {request} />
   </div>
 
-  <div class="from-to flex justify-between black fs-14 mb-1">
+  <div class="from-to flex justify-between black fs-14 mb-1 px-3">
     <div>
       <div class="uppercase fs-10">from</div>
       {#if from }
@@ -88,7 +88,7 @@
     </div>
   </div>
 
-  <div class="content multi-line-truncate line-clamp-3 fs-12 gray mb-2">
+  <div class="content multi-line-truncate line-clamp-3 fs-12 gray mb-2 px-3">
     {request.description  || ''}
   </div>
 </Card>

--- a/src/components/RequestCard.svelte
+++ b/src/components/RequestCard.svelte
@@ -28,6 +28,10 @@
     -webkit-line-clamp: 1; /* number of lines to show */
   }
 
+  .line-clamp-2.smaller {
+    -webkit-line-clamp: 2; /* number of lines to show */
+  }
+
   .line-clamp-3 {
     -webkit-line-clamp: 3; /* number of lines to show */
   }
@@ -58,7 +62,7 @@
   <div class="flex justify-between align-items-center black m-2 px-2">
     <UserAvatar {user} small />
 
-    <div>
+    <div class="px-2">
       <h5 class="multi-line-truncate my-0" class:smaller>{request.title}</h5>
 
       <div class="multi-line-truncate" class:smaller>{user.nickname}</div>
@@ -88,7 +92,7 @@
     </div>
   </div>
 
-  <div class="content multi-line-truncate line-clamp-3 fs-12 gray mb-2 px-3">
+  <div class="content multi-line-truncate line-clamp-3 line-clamp-2 fs-12 gray mb-2 px-3"  class:smaller>
     {request.description  || ''}
   </div>
 </Card>

--- a/src/components/RequestCard.svelte
+++ b/src/components/RequestCard.svelte
@@ -72,7 +72,7 @@
   </div>
 
   <div class="from-to flex justify-between black fs-14 mb-1 px-3">
-    <div>
+    <div class="pr-3">
       <div class="uppercase fs-10">from</div>
       {#if from }
         <p class="mb-1" class:smaller>{from}</p>


### PR DESCRIPTION
I realized the image shown in the [design](https://www.figma.com/file/qJ07Em4YDpfrwFg6YX8mTz/WeCarry?node-id=6591%3A35896) had no padding, but had to update Card in ui-components to change this. I noticed a few other things on the way.
- updated ui-components to 2.2.0
- removed padding from image
- added right padding to from div
- added .line-clamp.smaller
- added px-2 to title

Before (note image padding due to built in Card padding):
![Screen Shot 2021-07-13 at 11 06 04 PM](https://user-images.githubusercontent.com/70765247/125711566-03ee774f-256c-4538-bdff-de6e72cb0bba.png)

After:
normal size
![Screen Shot 2021-07-14 at 9 02 29 PM](https://user-images.githubusercontent.com/70765247/125711740-f08b1249-6333-4e13-94da-de005d09e6cf.png)
smaller (note only 2 lines for description)
![Screen Shot 2021-07-14 at 9 03 09 PM](https://user-images.githubusercontent.com/70765247/125711766-f894182a-4508-4bf0-96c5-bc9fb1f88250.png)

