### PR TITLE
fix smaller RequestCard

### DIFF
--- a/src/components/OtherRequestsBy.svelte
+++ b/src/components/OtherRequestsBy.svelte
@@ -29,7 +29,7 @@ hr {
     <div class="col-12"><h4>{requester.nickname}'s other requests</h4></div>
     {#each otherRequests as otherRequest }
       <div class="col-auto">
-        <div class="request-tile-container"><RequestCard request={otherRequest} smaller /></div>
+        <div class="request-tile-container h-100"><RequestCard request={otherRequest} smaller /></div>
       </div>
     {/each}
   </div>

--- a/src/components/RequestCard.svelte
+++ b/src/components/RequestCard.svelte
@@ -36,10 +36,6 @@
     -webkit-line-clamp: 2; /* number of lines to show */
   }
 
-  .line-clamp-1.smaller {
-    -webkit-line-clamp: 1;
-  }
-
   .line-clamp-3 {
     -webkit-line-clamp: 3;
   }

--- a/src/components/RequestCard.svelte
+++ b/src/components/RequestCard.svelte
@@ -19,6 +19,10 @@
     overflow-wrap: anywhere;
   }
 
+  .content.smaller {
+    -webkit-line-clamp: 1;
+  }
+
   .header {
     padding-left: 6px;
   }
@@ -29,15 +33,15 @@
     text-overflow: ellipsis;
     display: -webkit-box;
     -webkit-box-orient: vertical;
-    -webkit-line-clamp: 1; /* number of lines to show */
-  }
-
-  .line-clamp-2.smaller {
     -webkit-line-clamp: 2; /* number of lines to show */
   }
 
+  .line-clamp-1.smaller {
+    -webkit-line-clamp: 1;
+  }
+
   .line-clamp-3 {
-    -webkit-line-clamp: 3; /* number of lines to show */
+    -webkit-line-clamp: 3;
   }
 
   .request-image {
@@ -60,6 +64,11 @@
   .from-to {
     height: 3.5rem;
   }
+
+  .from-to.smaller {
+    height: auto;
+    display: block;
+  }
 </style>
 
 <Card isClickable noPadding on:click={gotoRequest} on:keypress={gotoRequest} class="h-100 py-1">
@@ -71,19 +80,20 @@
 
       <div class="multi-line-truncate fs-14" class:smaller>{user.nickname}</div>
     </div>
-
-    <span class="material-icons">chat</span>
+    {#if !smaller}
+      <span class="material-icons">chat</span>
+    {/if}
   </div>
 
   <div class="card-img-top request-image text-center mb-2" class:smaller>
     <RequestImage {request} />
   </div>
 
-  <div class="from-to flex justify-between black fs-14 mb-1 px-3">
+  <div class="from-to flex justify-between black fs-14 mb-1 px-3" class:smaller>
     <div class="pr-3">
       <div class="uppercase fs-10">from</div>
       {#if from }
-        <p class="mb-1" class:smaller>{from}</p>
+        <p class="mb-1 multi-line-truncate" class:smaller>{from}</p>
       {:else}
         <p class="mb-1 font-italic" class:smaller>anywhere</p>
       {/if}
@@ -92,11 +102,11 @@
     <div>
       <div class="uppercase fs-10">to</div>
 
-      <p class="mb-1" class:smaller>{to}</p>
+      <p class="mb-1 multi-line-truncate" class:smaller>{to}</p>
     </div>
   </div>
 
-  <div class="content multi-line-truncate line-clamp-3 line-clamp-2 fs-12 gray mb-2 px-3"  class:smaller>
+  <div class="content multi-line-truncate line-clamp-3 fs-12 gray mb-2 px-3"  class:smaller>
     {request.description  || ''}
   </div>
 </Card>


### PR DESCRIPTION
- fixed layout of smaller RequestCard for narrow columns - I realize there isn't a design made but wanted them usable for whenever we release and it wasn't difficult.
- clamp header at 2 lines instead of 1 - not sure if this is what we want, but that's how RequestTile was.

![Screen Shot 2021-07-16 at 11 39 12 AM](https://user-images.githubusercontent.com/70765247/125974569-0c6dae8a-4d6a-4efd-8b25-1fc59afae6bc.png)
![Screen Shot 2021-07-16 at 11 39 28 AM](https://user-images.githubusercontent.com/70765247/125974585-7e73e3cf-0183-40a0-aca3-5ffeebd21a13.png)
