### PR TITLE
show event name on request detail page

### DIFF
--- a/src/components/Request.svelte
+++ b/src/components/Request.svelte
@@ -66,7 +66,13 @@ function goToConversation(conversationId) {
           <h3 class="card-title">{ request.title || ''}</h3>
           <dl class="row">
             <dt class={dlTermColumns}>Deliver to</dt>
-            <dd class={dlDescriptionColumns}>{ destination }</dd>
+            <dd class={dlDescriptionColumns}>
+              {#if request.meeting}
+                <span class="badge badge-pill badge-info mr-2 align-text-top">Event</span>{request.meeting.name}
+              {:else}
+                { destination }
+              {/if}
+            </dd>
 
             <dt class={dlTermColumns}>From</dt>
             <dd class={dlDescriptionColumns}>


### PR DESCRIPTION
[Trello card](https://trello.com/c/NcGrkzXU/372-show-meeting-on-request-detail-page)

example:

![image](https://user-images.githubusercontent.com/3172830/126401755-98dc88e8-2ca9-4a45-b80d-77bfe2744f5d.png)
